### PR TITLE
Add verification preference support

### DIFF
--- a/avr/platform.txt
+++ b/avr/platform.txt
@@ -104,11 +104,17 @@ tools.avrdude.config.path={runtime.platform.path}/avrdude.conf
 
 tools.avrdude.upload.params.verbose=-v
 tools.avrdude.upload.params.quiet=-q -q
-tools.avrdude.upload.pattern="{cmd.path}" "-C{config.path}" {upload.verbose} -p{build.mcu} -c{upload.protocol} -Uhfuse:w:{bootloader.high_fuses}:m -Ulfuse:w:{bootloader.low_fuses}:m -D "-Uflash:w:{build.path}/{build.project_name}.hex:i"
+# tools.avrdude.upload.verify is needed for backwards compatibility with AVRDUDE 6.3.0 and IDE 1.6.8 or older, IDE 1.6.9 or newer overrides this value
+tools.avrdude.upload.verify=
+tools.avrdude.upload.params.noverify=-V
+tools.avrdude.upload.pattern="{cmd.path}" "-C{config.path}" {upload.verbose} {upload.verify} -p{build.mcu} -c{upload.protocol} -Uhfuse:w:{bootloader.high_fuses}:m -Ulfuse:w:{bootloader.low_fuses}:m -D "-Uflash:w:{build.path}/{build.project_name}.hex:i"
 
 tools.avrdude.program.params.verbose=-v
 tools.avrdude.program.params.quiet=-q -q
-tools.avrdude.program.pattern="{cmd.path}" "-C{config.path}" {program.verbose} -p{build.mcu} -c{upload.protocol} {program.extra_params}  -Uhfuse:w:{bootloader.high_fuses}:m -Ulfuse:w:{bootloader.low_fuses}:m "-Uflash:w:{build.path}/{build.project_name}.hex:i"
+# tools.avrdude.program.verify is needed for backwards compatibility with AVRDUDE 6.3.0 and IDE 1.6.8 or older, IDE 1.6.9 or newer overrides this value
+tools.avrdude.program.verify=
+tools.avrdude.program.params.noverify=-V
+tools.avrdude.program.pattern="{cmd.path}" "-C{config.path}" {program.verbose} {program.verify} -p{build.mcu} -c{upload.protocol} {program.extra_params}  -Uhfuse:w:{bootloader.high_fuses}:m -Ulfuse:w:{bootloader.low_fuses}:m "-Uflash:w:{build.path}/{build.project_name}.hex:i"
 
 tools.avrdude.erase.params.verbose=-v
 tools.avrdude.erase.params.quiet=-q -q


### PR DESCRIPTION
Post-upload program verification can be controlled via **File >Preferences > Verify code after upload** in Arduino IDE 1.6.9 and newer. Default values of the `upload.verify` and `program.verify` properties must
be set in order for an AVRDUDE command to be generated in Arduino IDE 1.6.8 and older that is compatible with AVRDUDE 6.3.0.

MicroCore's `tools.avrdude.program` items are only used when one of the **(slow)** programmer options are selected. This means that **Upload Using Programmer** will still not be compatible with Arduino IDE 1.6.8 or older using Arduino AVR Boards 1.6.12 or 1.6.14 when one of the standard **Tools > Programmer** menu selections are used since the platform.txt associated with the selected programmer is used for Upload Using Programmer.
