### PR TITLE
Use ATOMIC_BLOCK instead of cli() and sei()

### DIFF
--- a/avr/libraries/AVR_examples/examples/WDT_interrupt/WDT_interrupt.ino
+++ b/avr/libraries/AVR_examples/examples/WDT_interrupt/WDT_interrupt.ino
@@ -11,23 +11,23 @@
 #include <avr/io.h>
 #include <avr/interrupt.h>
 #include <avr/wdt.h>
+#include <util/atomic.h>
 
 int main(void)
 {
-  cli(); // Turn off global interrupts
-
-  DDRB |= _BV(PB2); // Set PB2 as output
-  
-  wdt_reset(); // Reset watchdog
-
-  // Turn on WDT interrupt and cause an interrupt every 500 ms
-  // Read more about how to change the interrupt delay on page
-  // 42 in the ATtiny13 datasheet
-  // http://www.atmel.com/images/doc2535.pdf
-  WDTCR = _BV(WDTIE) | _BV(WDP2) | _BV(WDP0); 
-
-  sei(); // Turn on global interrupts
-  
+  // Disable global interrupts, then enable them afterwards
+  ATOMIC_BLOCK(ATOMIC_FORCEON)
+  {
+    DDRB |= _BV(PB2); // Set PB2 as output
+    
+    wdt_reset(); // Reset watchdog
+    
+    // Turn on WDT interrupt and cause an interrupt every 500 ms
+    // Read more about how to change the interrupt delay on page
+    // 42 in the ATtiny13 datasheet
+    // http://www.atmel.com/images/doc2535.pdf
+    WDTCR = _BV(WDTIE) | _BV(WDP2) | _BV(WDP0);
+  }
   while(1); // Wait forever
 }
 


### PR DESCRIPTION
Use macros from util/atomic.h to prevent blocks of code from being
interrupted by interrupts.

`ATOMIC_BLOCK(ATOMIC_FORCEON) { /*...*/ }` is used in place of
`cli(); /*...*/ sei();` when global interrupts are already on, or when
global interrupts must be enabled afterwards anyway.

`ATOMIC_BLOCK(ATOMIC_RESTORESTATE) { /*...*/ }` is used to save the
state of SREG (including the Global Interrupt Status flag) and restore
it afterwards.