### PR TITLE
Adding debugWIRE programmer

### DIFF
--- a/avr/platform.txt
+++ b/avr/platform.txt
@@ -126,6 +126,10 @@ tools.avrdude.bootloader.params.verbose=-v
 tools.avrdude.bootloader.params.quiet=-q -q
 tools.avrdude.bootloader.pattern="{cmd.path}" "-C{config.path}" {bootloader.verbose} -p{build.mcu} -c{protocol} -B32 {program.extra_params} -Ulock:w:{bootloader.lock_bits}:m
 
+tools.atprogram.program.params.verbose=-v
+tools.atprogram.program.params.quiet=-q
+tools.atprogram.program.pattern="C:\Program Files (x86)\Atmel\Studio\7.0\atbackend\atprogram.exe" -t atmelice -i debugWIRE -d attiny13a program -f {build.path}\{build.project_name}.hex
+
 # USB Default Flags
 # Default blank usb manufacturer will be filled it at compile time
 # - from numeric vendor ID, set to Unknown otherwise

--- a/avr/programmers.txt
+++ b/avr/programmers.txt
@@ -96,3 +96,9 @@ atmel_ice.upload.protocol=atmelice_isp
 atmel_ice.program.protocol=atmelice_isp
 atmel_ice.program.tool=avrdude
 atmel_ice.program.extra_params=-Pusb -B32
+
+atmel_ice_dw.name=Atmel-ICE debugWIRE
+atmel_ice_dw.communication=usb
+atmel_ice_dw.protocol=atmelice_dw
+atmel_ice_dw.program.protocol=atmelice_dw
+atmel_ice_dw.program.tool=atprogram


### PR DESCRIPTION
Hi there, I usually flash the fuses over SPI first (DWEN), then using debugWIRE, so I've added new programming tool. Would be nice to have it merged when considered useful. Thanks. Please note it requires Atmel Studio, maybe just a part of it.