### PR TITLE
Add Serial/UART support and oscillator calibration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,9 @@ env:
     # Arduino IDE 1.6.3-1.6.5-r5 on Linux don't seem to include the MicroCore bundled library files (this information copied from MegaCore so may not apply to MicroCore).
     # Arduino IDE 1.6.6 has many function prototype generation failures.
     # So testing is done with milestone Arduino IDE versions, 1.6.7 and newer.
-    - IDE_VERSIONS_BEFORE_OLDEST_IDE_VERSION_TO_TEST_WITH_LTO='"1.6.7" "1.6.9"'
     - IDE_VERSIONS_FROM_OLDEST_IDE_VERSION_TO_TEST_WITH_LTO='"'"$OLDEST_IDE_VERSION_TO_TEST_WITH_LTO"'" "1.6.13" "1.8.0" "1.8.5" "newest"'
     - IDE_VERSION_LIST_LTO='('"$IDE_VERSIONS_FROM_OLDEST_IDE_VERSION_TO_TEST_WITH_LTO"')'
-    - IDE_VERSION_LIST_FULL='('"${IDE_VERSIONS_BEFORE_OLDEST_IDE_VERSION_TO_TEST_WITH_LTO} ${IDE_VERSIONS_FROM_OLDEST_IDE_VERSION_TO_TEST_WITH_LTO}"')'
+    - IDE_VERSION_LIST_FULL='('"${IDE_VERSIONS_FROM_OLDEST_IDE_VERSION_TO_TEST_WITH_LTO}"')'
 
 
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ env:
   matrix:
     # clock=9M6, BOD=2v7, lto=Os_flto, millis enabled, micros disabled
     - BOARD_ID="MicroCore:avr:attiny13:clock=9M6,BOD=2v7,lto=Os_flto,timing=millis_enabled_micros_disabled" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
+    # clock=9M6, BOD=2v7, lto=Os, millis enabled, micros disabled
+    - BOARD_ID="MicroCore:avr:attiny13:clock=9M6,BOD=2v7,lto=Os,timing=millis_enabled_micros_disabled" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
     # clock=9M6, BOD=2v7, lto=Os_flto, millis enabled, micros enabled
     - BOARD_ID="MicroCore:avr:attiny13:clock=9M6,BOD=2v7,lto=Os_flto,timing=millis_enabled_micros_enabled" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
     # clock=9M6, BOD=2v7, lto=Os_flto, millis disabled, micros enabled
@@ -32,34 +34,34 @@ env:
     # clock=9M6, BOD=2v7, lto=Os_flto, millis disabled, micros disabled
     - BOARD_ID="MicroCore:avr:attiny13:clock=9M6,BOD=2v7,lto=Os_flto,timing=millis_disabled_micros_disabled" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
     
-    # clock=4M8, BOD=4v3, lto=Os, millis enabled, micros disabled
-    - BOARD_ID="MicroCore:avr:attiny13:clock=4M8,BOD=4v3,lto=Os,timing=millis_enabled_micros_disabled" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=4M8, BOD=4v3, lto=Os_flto, millis enabled, micros disabled
+    - BOARD_ID="MicroCore:avr:attiny13:clock=4M8,BOD=4v3,lto=Os_flto,timing=millis_enabled_micros_disabled" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
     
-    # clock=1M2, BOD=1v8, lto=Os, millis enabled, micros enabled
-    - BOARD_ID="MicroCore:avr:attiny13:clock=1M2,BOD=1v8,lto=Os,timing=millis_enabled_micros_enabled" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=1M2, BOD=1v8, lto=Os_flto, millis enabled, micros enabled
+    - BOARD_ID="MicroCore:avr:attiny13:clock=1M2,BOD=1v8,lto=Os_flto,timing=millis_enabled_micros_enabled" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
     
-    # clock=600k, BOD=disabled, lto=Os, millis enabled, micros disabled
-    - BOARD_ID="MicroCore:avr:attiny13:clock=600k,BOD=disabled,lto=Os,timing=millis_enabled_micros_disabled" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=600k, BOD=disabled, lto=Os_flto, millis enabled, micros disabled
+    - BOARD_ID="MicroCore:avr:attiny13:clock=600k,BOD=disabled,lto=Os_flto,timing=millis_enabled_micros_disabled" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
     
-    # clock=128k, BOD=2v7, lto=Os, millis enabled, micros disabled
-    - BOARD_ID="MicroCore:avr:attiny13:clock=128k,BOD=2v7,lto=Os,timing=millis_enabled_micros_disabled" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=128k, BOD=2v7, lto=Os_flto, millis enabled, micros disabled
+    - BOARD_ID="MicroCore:avr:attiny13:clock=128k,BOD=2v7,lto=Os_flto,timing=millis_enabled_micros_disabled" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
     
-    # clock=20M, BOD=2v7, lto=Os, millis enabled, micros disabled
-    - BOARD_ID="MicroCore:avr:attiny13:clock=20M,BOD=2v7,lto=Os,timing=millis_enabled_micros_disabled" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=20M, BOD=2v7, lto=Os_flto, millis enabled, micros disabled
+    - BOARD_ID="MicroCore:avr:attiny13:clock=20M,BOD=2v7,lto=Os_flto,timing=millis_enabled_micros_disabled" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
     
-    # clock=16M, BOD=2v7, lto=Os, millis enabled, micros disabled
-    - BOARD_ID="MicroCore:avr:attiny13:clock=16M,BOD=2v7,lto=Os,timing=millis_enabled_micros_disabled" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-     # clock=16M, BOD=2v7, lto=Os, millis enabled, micros enabled
-    - BOARD_ID="MicroCore:avr:attiny13:clock=16M,BOD=2v7,lto=Os,timing=millis_enabled_micros_enabled" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=16M, BOD=2v7, lto=Os_flto, millis enabled, micros disabled
+    - BOARD_ID="MicroCore:avr:attiny13:clock=16M,BOD=2v7,lto=Os_flto,timing=millis_enabled_micros_disabled" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=16M, BOD=2v7, lto=Os_flto, millis enabled, micros enabled
+    - BOARD_ID="MicroCore:avr:attiny13:clock=16M,BOD=2v7,lto=Os_flto,timing=millis_enabled_micros_enabled" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
     
-    # clock=12M, BOD=2v7, lto=Os, millis enabled, micros disabled
-    - BOARD_ID="MicroCore:avr:attiny13:clock=12M,BOD=2v7,lto=Os,timing=millis_enabled_micros_disabled" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=12M, BOD=2v7, lto=Os_flto, millis enabled, micros disabled
+    - BOARD_ID="MicroCore:avr:attiny13:clock=12M,BOD=2v7,lto=Os_flto,timing=millis_enabled_micros_disabled" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
     
-    # clock=8M, BOD=2v7, lto=Os, millis enabled, micros disabled
-    - BOARD_ID="MicroCore:avr:attiny13:clock=8M,BOD=2v7,lto=Os,timing=millis_enabled_micros_disabled" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=8M, BOD=2v7, lto=Os_flto, millis enabled, micros disabled
+    - BOARD_ID="MicroCore:avr:attiny13:clock=8M,BOD=2v7,lto=Os_flto,timing=millis_enabled_micros_disabled" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
     
-    # clock=1M, BOD=2v7, lto=Os, millis enabled, micros disabled
-    - BOARD_ID="MicroCore:avr:attiny13:clock=1M,BOD=2v7,lto=Os,timing=millis_enabled_micros_disabled" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=1M, BOD=2v7, lto=Os_flto, millis enabled, micros disabled
+    - BOARD_ID="MicroCore:avr:attiny13:clock=1M,BOD=2v7,lto=Os_flto,timing=millis_enabled_micros_disabled" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
 
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,45 +23,45 @@ env:
 
 
   matrix:
-    # clock=9M6, BOD=2v7, lto=Os_flto, millis enabled, micros disabled
-    - BOARD_ID="MicroCore:avr:attiny13:clock=9M6,BOD=2v7,lto=Os_flto,timing=millis_enabled_micros_disabled" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
-    # clock=9M6, BOD=2v7, lto=Os, millis enabled, micros disabled
-    - BOARD_ID="MicroCore:avr:attiny13:clock=9M6,BOD=2v7,lto=Os,timing=millis_enabled_micros_disabled" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
-    # clock=9M6, BOD=2v7, lto=Os_flto, millis enabled, micros enabled
-    - BOARD_ID="MicroCore:avr:attiny13:clock=9M6,BOD=2v7,lto=Os_flto,timing=millis_enabled_micros_enabled" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
-    # clock=9M6, BOD=2v7, lto=Os_flto, millis disabled, micros enabled
-    - BOARD_ID="MicroCore:avr:attiny13:clock=9M6,BOD=2v7,lto=Os_flto,timing=millis_disabled_micros_enabled" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
-    # clock=9M6, BOD=2v7, lto=Os_flto, millis disabled, micros disabled
-    - BOARD_ID="MicroCore:avr:attiny13:clock=9M6,BOD=2v7,lto=Os_flto,timing=millis_disabled_micros_disabled" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
+    # clock=9M6, BOD=2v7, millis enabled, micros disabled
+    - BOARD_ID="MicroCore:avr:attiny13:clock=9M6,BOD=2v7,timing=millis_enabled_micros_disabled" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
+    # clock=9M6, BOD=2v7, millis enabled, micros disabled
+    - BOARD_ID="MicroCore:avr:attiny13:clock=9M6,BOD=2v7,timing=millis_enabled_micros_disabled" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
+    # clock=9M6, BOD=2v7, millis enabled, micros enabled
+    - BOARD_ID="MicroCore:avr:attiny13:clock=9M6,BOD=2v7,timing=millis_enabled_micros_enabled" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
+    # clock=9M6, BOD=2v7, millis disabled, micros enabled
+    - BOARD_ID="MicroCore:avr:attiny13:clock=9M6,BOD=2v7,timing=millis_disabled_micros_enabled" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
+    # clock=9M6, BOD=2v7, millis disabled, micros disabled
+    - BOARD_ID="MicroCore:avr:attiny13:clock=9M6,BOD=2v7,timing=millis_disabled_micros_disabled" IDE_VERSIONS="$IDE_VERSION_LIST_LTO"
     
-    # clock=4M8, BOD=4v3, lto=Os_flto, millis enabled, micros disabled
-    - BOARD_ID="MicroCore:avr:attiny13:clock=4M8,BOD=4v3,lto=Os_flto,timing=millis_enabled_micros_disabled" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=4M8, BOD=4v3, millis enabled, micros disabled
+    - BOARD_ID="MicroCore:avr:attiny13:clock=4M8,BOD=4v3,timing=millis_enabled_micros_disabled" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
     
-    # clock=1M2, BOD=1v8, lto=Os_flto, millis enabled, micros enabled
-    - BOARD_ID="MicroCore:avr:attiny13:clock=1M2,BOD=1v8,lto=Os_flto,timing=millis_enabled_micros_enabled" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=1M2, BOD=1v8, millis enabled, micros enabled
+    - BOARD_ID="MicroCore:avr:attiny13:clock=1M2,BOD=1v8,timing=millis_enabled_micros_enabled" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
     
-    # clock=600k, BOD=disabled, lto=Os_flto, millis enabled, micros disabled
-    - BOARD_ID="MicroCore:avr:attiny13:clock=600k,BOD=disabled,lto=Os_flto,timing=millis_enabled_micros_disabled" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=600k, BOD=disabled, millis enabled, micros disabled
+    - BOARD_ID="MicroCore:avr:attiny13:clock=600k,BOD=disabled,timing=millis_enabled_micros_disabled" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
     
-    # clock=128k, BOD=2v7, lto=Os_flto, millis enabled, micros disabled
-    - BOARD_ID="MicroCore:avr:attiny13:clock=128k,BOD=2v7,lto=Os_flto,timing=millis_enabled_micros_disabled" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=128k, BOD=2v7, millis enabled, micros disabled
+    - BOARD_ID="MicroCore:avr:attiny13:clock=128k,BOD=2v7,timing=millis_enabled_micros_disabled" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
     
-    # clock=20M, BOD=2v7, lto=Os_flto, millis enabled, micros disabled
-    - BOARD_ID="MicroCore:avr:attiny13:clock=20M,BOD=2v7,lto=Os_flto,timing=millis_enabled_micros_disabled" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=20M, BOD=2v7, millis enabled, micros disabled
+    - BOARD_ID="MicroCore:avr:attiny13:clock=20M,BOD=2v7,timing=millis_enabled_micros_disabled" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
     
-    # clock=16M, BOD=2v7, lto=Os_flto, millis enabled, micros disabled
-    - BOARD_ID="MicroCore:avr:attiny13:clock=16M,BOD=2v7,lto=Os_flto,timing=millis_enabled_micros_disabled" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
-    # clock=16M, BOD=2v7, lto=Os_flto, millis enabled, micros enabled
-    - BOARD_ID="MicroCore:avr:attiny13:clock=16M,BOD=2v7,lto=Os_flto,timing=millis_enabled_micros_enabled" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=16M, BOD=2v7, millis enabled, micros disabled
+    - BOARD_ID="MicroCore:avr:attiny13:clock=16M,BOD=2v7,timing=millis_enabled_micros_disabled" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=16M, BOD=2v7, millis enabled, micros enabled
+    - BOARD_ID="MicroCore:avr:attiny13:clock=16M,BOD=2v7,timing=millis_enabled_micros_enabled" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
     
-    # clock=12M, BOD=2v7, lto=Os_flto, millis enabled, micros disabled
-    - BOARD_ID="MicroCore:avr:attiny13:clock=12M,BOD=2v7,lto=Os_flto,timing=millis_enabled_micros_disabled" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=12M, BOD=2v7, millis enabled, micros disabled
+    - BOARD_ID="MicroCore:avr:attiny13:clock=12M,BOD=2v7,timing=millis_enabled_micros_disabled" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
     
-    # clock=8M, BOD=2v7, lto=Os_flto, millis enabled, micros disabled
-    - BOARD_ID="MicroCore:avr:attiny13:clock=8M,BOD=2v7,lto=Os_flto,timing=millis_enabled_micros_disabled" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=8M, BOD=2v7, millis enabled, micros disabled
+    - BOARD_ID="MicroCore:avr:attiny13:clock=8M,BOD=2v7,timing=millis_enabled_micros_disabled" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
     
-    # clock=1M, BOD=2v7, lto=Os_flto, millis enabled, micros disabled
-    - BOARD_ID="MicroCore:avr:attiny13:clock=1M,BOD=2v7,lto=Os_flto,timing=millis_enabled_micros_disabled" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
+    # clock=1M, BOD=2v7, millis enabled, micros disabled
+    - BOARD_ID="MicroCore:avr:attiny13:clock=1M,BOD=2v7,timing=millis_enabled_micros_disabled" IDE_VERSIONS="$IDE_VERSION_LIST_FULL"
 
 
 before_install:

--- a/README.md
+++ b/README.md
@@ -124,8 +124,9 @@ This diagram shows the pinout and the peripherals of ATtiny13. The Arduino pinou
 
 
 ## Minimal setup
-<br/>
-<img src="http://i.imgur.com/SjCN7oZ.png" width="600">
+<b>Click to enlarge:</b> 
+</br> </br>
+<img src="https://i.imgur.com/TI43e2k.png" width="600">
 
 
 ## Working Arduino functions and libaraies

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ If you're into low level AVR programming, I'm happy to tell you that all relevan
 * [Supported clock frequencies](#supported-clock-frequencies)
 * [LTO](#lto)
 * [BOD option](#bod-option)
-* [Timing options](#timing-option)
+* [Timing options](#timing-options)
+* [Serial support](#serial-support)
+  - [Internal oscillator calibration](#internal-oscillator-calibration)
 * [Programmers](#programmers)
 * **[Core settings](#core-settings)**
 * **[How to install](#how-to-install)**
@@ -40,7 +42,7 @@ The ATtiny13 has several internal oscillators, and these are the available clock
 * 600 kHz internal oscillator
 * 128 kHz internal watchdog oscillator <b>*</b>
 
-If you want other or higher clock frequencies, you can apply an external clock source. Note that the ATtiny13 requires an external clock signal, and is not able to drive a resonator circuit itself. You may use a [quartz crystal oscillator](https://en.wikipedia.org/wiki/Crystal_oscillator#/media/File:18MHZ_12MHZ_Crystal_110.jpg).
+If you want other or higher clock frequencies, you can apply an external clock source. Note that the ATtiny13 requires an external clock signal, and is not able to drive a resonator circuit itself. You may use a quartz crystal oscillator or a crystal driver (shown in [minimal setup](#minimal-setup)).
 Supported external clock frequencies:
 * 20 MHz external oscillator
 * 16 MHz external oscillator
@@ -69,8 +71,38 @@ These are the available BOD options:
 
 
 ## Timing options
-You can choose to enable or disable millis() and micros() directly from the Timing menu. Great if you want to save some flash memory!
+You can choose to enable or disable millis() and micros() directly from the timing menu. Great if you want to save some flash memory!
 
+## Serial support
+MicroCore features a brilliant, ultra-lightweight software UART library wrapped by `Serial`. This means you can use regular `Serial.print()`if you need to. Note that the baud rate has to be defined at compile-time and cannot be defined in the sketch. The table below shows a list of which clock frequencies use which baud rates by default. If you need a different baud rate for a specific clock frequency, you may modify the [core_settings.h file](#core-settings).
+
+If you want to use the UART functionality you will have to have the right hardware connected to the right pins on the ATtiny13. See the [minimal setup section](#minimal-setup) for more information. Also, please have a look at the provided [serial example sketches](https://github.com/MCUdude/MicroCore/tree/master/avr/libraries/Serial_exampes/examples).
+
+| Clock              | Baud rate     |
+|--------------------|---------------|
+| (External) 20 MHz  | 115200        |
+| (External) 16 MHz  | 115200        |
+| (External) 12 MHz  | 115200        |
+| (External) 8 MHz   | 115200        |
+| (External) 1 MHz   | 19200         |
+| (Internal) 9.6 MHz | 115200        |
+| (Internal) 4.8 MHz | 57600         |
+| (Internal) 1.2 MHz | 19200         |
+| (Internal) 600 kHz | 9600          |
+| (Internal) 128 kHz | Not supported |
+
+### Internal oscillator calibration
+The internal 9.6 and 4.8 MHz internal oscillators (yes, these are separate) in the ATtiny13 are usually not very accurate. This is OK for many applications, but when you're using an asynchronous protocol like UART, ±3-4% off simply won't work. To solve this problem MicroCore provides a very user-friendly [Oscillator calibration sketch](https://github.com/MCUdude/MicroCore/blob/master/avr/libraries/Serial_exampes/examples/OscillatorCalibration/OscillatorCalibration.ino) that calculate a new OSCCAL value based on a received character over UART. All you need to do is to load the sketch, select the correct baud rate in the serial monitor, select *No line ending* and send the `x` character many times (`x` [send], `x` [send] ...). After a few tries, you should gradually see readable text in the serial monitor. After the calibration value has stabilized it's automatically stored in EEPROM address 0 for future use. This value is not loaded by default, but has to be loaded "manually" in your sketch like so:
+
+```c++
+  // Check if there exist any OSCCAL value in EEPROM addr. 0
+  // If not, run the oscillator tuner sketch first
+  uint8_t cal = EEPROM.read(0);
+  if(cal < 0x7F)
+    OSCCAL = cal;
+```
+
+Huge thanks to [Ralph Doncaster](https://github.com/nerdralph) for providing his excellent sofware serial library and his oscillator calibration code. None of this would be close to possible if it weren't for his brilliant work!
 
 ## Programmers
 When the ATtiny13 is running from the internal 128 kHz oscillator, it's too slow to interact with the programming tool. That's why this core adds some additional programmers to the list, with the suffix *(slow)*. These options makes the programmers run at a lower clock speed, so the microcontroller can keep up.
@@ -129,7 +161,7 @@ This diagram shows the pinout and the peripherals of ATtiny13. The Arduino pinou
 <img src="https://i.imgur.com/TI43e2k.png" width="600">
 
 
-## Working Arduino functions and libaraies
+## Working Arduino functions and libraries
 Due to the limited hardware not all default Arduino functions and libraries is supported by the ATtiny13. Here's a list of all working Arduino functions and libraries that's included in the MicroCore package.
 
 ### Arduino functions

--- a/avr/boards.txt
+++ b/avr/boards.txt
@@ -29,6 +29,12 @@ attiny13.build.mcu_compile=attiny13a
 attiny13.build.mcu=attiny13
 attiny13.build.variant=attiny13
 
+attiny13.compiler.c.extra_flags=-Wextra -flto -g
+attiny13.compiler.c.elf.extra_flags=-w -flto -g
+attiny13.compiler.cpp.extra_flags=-Wextra -flto -g
+attiny13.compiler.flag_indicator=-D COMPILER_LTO
+attiny13.ltoarcmd=avr-gcc-ar
+
 
 ######################
 #### Clock speeds ####
@@ -98,24 +104,6 @@ attiny13.menu.BOD.1v8.bootloader.high_fuses=0xfd
 attiny13.menu.BOD.disabled=BOD disabled
 attiny13.menu.BOD.disabled.bootloader.high_fuses=0xff
 
-
-#############
-#### LTO ####
-#############
-
-attiny13.menu.lto.Os_flto=LTO enabled (default)
-attiny13.menu.lto.Os_flto.compiler.c.extra_flags=-Wextra -flto -g
-attiny13.menu.lto.Os_flto.compiler.c.elf.extra_flags=-w -flto -g
-attiny13.menu.lto.Os_flto.compiler.cpp.extra_flags=-Wextra -flto -g
-attiny13.menu.lto.Os_flto.compiler.flag_indicator=-D COMPILER_LTO
-attiny13.menu.lto.Os_flto.ltoarcmd=avr-gcc-ar
-
-attiny13.menu.lto.Os=LTO disabled
-attiny13.menu.lto.Os.compiler.c.extra_flags=
-attiny13.menu.lto.Os.compiler.c.elf.extra_flags=
-attiny13.menu.lto.Os.compiler.cpp.extra_flags=
-attiny13.menu.lto.Os.compiler.flag_indicator=
-attiny13.menu.lto.Os.ltoarcmd=avr-ar
 
 
 ################

--- a/avr/cores/microcore/Arduino.h
+++ b/avr/cores/microcore/Arduino.h
@@ -115,6 +115,9 @@ extern "C"{
 
 
 #ifdef __cplusplus
+
+  #include "HalfDuplexSerial.h"
+
   // Tone functions
   void tone(uint8_t pin, uint16_t frequency, uint32_t duration = 0);
   void toneRaw(uint8_t pin, uint8_t midPoint, uint32_t lengthTicks, uint8_t prescaleBitMask);

--- a/avr/cores/microcore/HalfDuplexSerial.S
+++ b/avr/cores/microcore/HalfDuplexSerial.S
@@ -1,0 +1,119 @@
+/* optimized half-duplex serial uart implementation - 27 instructions
+ * @author: Ralph Doncaster 2014
+ *
+ * Modified by J.Sleeman (sparks@gogo.co.nz) to add Non Blocking reads
+ * RxByteNBZeroReturn   (returns BYTE 0 for no data [or null byte read])
+ * RxByteNBNegOneReturn (returns INT -1 for no data)
+ *
+ * Modified by MCUdude for the MicroCore
+ * https://github.com/MCUdude/MicroCore
+ */
+
+/* Notes:
+https://gcc.gnu.org/wiki/avr-gcc
+R18–R27, R30, R31
+These GPRs are call clobbered. An ordinary function may use them without restoring the contents. Interrupt service routines (ISRs) must save and restore each register they use.
+*/
+
+/* needed for <avr/io.h> to give io constant addresses */
+#define __SFR_OFFSET 0
+#include <avr/io.h>
+
+#define UART_Port PORTB
+#define UART_Tx 0
+#define UART_Rx 1
+
+#define delayArg r22
+
+// #define outRegister r0
+#define outRegister r18
+.extern TXDELAY
+.section .text.transmit,"ax",@progbits
+; transmit byte contained in r24
+; AVR305 has 1 cycle of jitter per bit, this has none
+.global TxByte
+TxByte:
+  cli
+  sbi UART_Port-1, UART_Tx   ; set Tx line to output
+  cbi UART_Port, UART_Tx     ; start bit
+  in outRegister, UART_Port
+  ldi r25, 7                 ; stop bit & idle state
+TxLoop:
+  ; 8 cycle loop + delay = 7 + 3*DelayArg
+  ldi delayArg, TXDELAY
+TxDelay:
+    dec delayArg
+  brne TxDelay
+  bst r24, 0                 ; store lsb in T
+  bld outRegister, UART_Tx
+  lsr r25
+  ror r24                    ; 2-byte shift register
+  out UART_Port, outRegister
+  brne TxLoop
+  sei
+  ret
+
+
+.extern RXSTART
+.extern RXDELAY
+
+.section .text.receive,"ax",@progbits
+; receive byte into r24
+.global RxByte
+
+RxByte:
+  sbic UART_Port-2, UART_Rx  ; wait for start edge
+  rjmp RxByte
+GotStartBit:
+  push r16
+  in r16, SREG               ; Save status register
+  cli                        ; Clear interrupts - if we allow interrupts here (eg for millis) we lose bits
+  ldi r24, 0x80              ; bit shift counter
+  ldi delayArg, RXSTART      ; 1.5 bit delay
+RxBit:
+  ; 7 cycle loop + delay = 7 + 6 + 3*DelayArg
+  rcall Delay3Cycle          ; delay and clear carry
+  ldi delayArg, RXDELAY
+  lsr r24
+  sbic UART_Port-2, UART_Rx
+  ori r24, 0x80
+    nop                      ; match 7-cycle Tx loop
+  brcc RxBit
+  ; fall into delay for stop bit
+  out SREG, r16 ; Return status register, this enables interrupts again
+  pop r16
+
+; delay (3 cycle * delayArg) -1 + 4 cycles (ret instruction)
+Delay3Cycle:
+  dec delayArg
+  brne Delay3Cycle
+  ret
+
+; We put these in their own section so the linker can drop them
+; if not used.
+.section .text.receivenb,"ax",@progbits
+.global RxByteNBNegOneReturn
+.global RxByteNBZeroReturn
+
+; Non-Blocking RX Byte with zero return
+RxByteNBZeroReturn:
+  sbic UART_Port-2, UART_Rx  ; wait for start edge
+  rjmp NoWaitRxZeroReturn    ; if no start, drop out with a zero return
+  rjmp GotStartBit           ; otherwise read the byte in
+
+RxByteNBNegOneReturn:
+  sbic UART_Port-2, UART_Rx  ; wait for start edge
+  rjmp NoWaitRxNegOneReturn  ; if no start, drop out with a zero return
+  ldi r25, 0x00              ; this routine will return an int,
+                             ; because Serial.write() does normally return -1 when no data is read
+                             ; since we are returning data set the upper byte of the int to zero
+  rjmp GotStartBit           ; read the bit in
+
+NoWaitRxNegOneReturn:
+  ldi r25, 0xFF              ; In non blocking mode we follow the standard "Serial.read()" return value of
+  ldi r24, 0xFF              ; -1 indicates no data read  ( signed int, 0xFFFF <-- [0x0000] --> 0x0001 )
+  ret
+
+NoWaitRxZeroReturn:
+  ldi r24, 0x00              ; 0 indicates no data read
+  ret

--- a/avr/cores/microcore/HalfDuplexSerial.S
+++ b/avr/cores/microcore/HalfDuplexSerial.S
@@ -12,7 +12,8 @@
 /* Notes:
 https://gcc.gnu.org/wiki/avr-gcc
 R18–R27, R30, R31
-These GPRs are call clobbered. An ordinary function may use them without restoring the contents. Interrupt service routines (ISRs) must save and restore each register they use.
+These GPRs are call clobbered. An ordinary function may use them without restoring the contents.
+Interrupt service routines (ISRs) must save and restore each register they use.
 */
 
 /* needed for <avr/io.h> to give io constant addresses */
@@ -25,45 +26,41 @@ These GPRs are call clobbered. An ordinary function may use them without restori
 
 #define delayArg r22
 
-// #define outRegister r0
-#define outRegister r18
 .extern TXDELAY
+.extern RXSTART
+.extern RXDELAY
+
 .section .text.transmit,"ax",@progbits
 ; transmit byte contained in r24
 ; AVR305 has 1 cycle of jitter per bit, this has none
 .global TxByte
 TxByte:
-  cli
-  sbi UART_Port-1, UART_Tx   ; set Tx line to output
-  cbi UART_Port, UART_Tx     ; start bit
-  in outRegister, UART_Port
-  ldi r25, 7                 ; stop bit & idle state
+  sbi UART_Port-1, UART_Tx    ; set Tx line to output
+  cbi UART_Port, UART_Tx      ; start bit
+  in r0, UART_Port
+  ldi r25, 7            ; stop bit & idle state
 TxLoop:
   ; 8 cycle loop + delay = 7 + 3*DelayArg
   ldi delayArg, TXDELAY
 TxDelay:
     dec delayArg
   brne TxDelay
-  bst r24, 0                 ; store lsb in T
-  bld outRegister, UART_Tx
+  bst r24, 0            ; store lsb in T
+  bld r0, UART_Tx
   lsr r25
-  ror r24                    ; 2-byte shift register
-  out UART_Port, outRegister
+  ror r24             ; 2-byte shift register
+  out UART_Port, r0
   brne TxLoop
-  sei
   ret
-
-
-.extern RXSTART
-.extern RXDELAY
 
 .section .text.receive,"ax",@progbits
 ; receive byte into r24
 .global RxByte
-
 RxByte:
   sbic UART_Port-2, UART_Rx  ; wait for start edge
   rjmp RxByte
+;  ldi r24, 0x80              ; bit shift counter
+;  ldi delayArg, RXSTART      ; 1.5 bit delay
 GotStartBit:
   push r16
   in r16, SREG               ; Save status register

--- a/avr/cores/microcore/HalfDuplexSerial.cpp
+++ b/avr/cores/microcore/HalfDuplexSerial.cpp
@@ -1,0 +1,136 @@
+/*
+  HalfDuplexSerial.cpp - Stream Wrapper for Raplh Doncaster's
+
+  Wrapper by J.Sleeman (sparks@gogo.co.nz), Derived from TinySoftwareSerial
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+  Modified by MCUdude for the MicroCore
+  https://github.com/MCUdude/MicroCore
+*/
+
+#include "Arduino.h"
+#include "HalfDuplexSerial.h"
+
+
+// Public Methods //////////////////////////////////////////////////////////////
+
+/*
+void HalfDuplexSerial::begin(const uint8_t baud)
+{
+
+}
+
+void HalfDuplexSerial::end()
+{
+  // We can not end
+}
+
+void HalfDuplexSerial::flush()
+{
+  // Nothing to do here
+}
+*/
+
+int HalfDuplexSerial::available(void)
+{
+  // There is never anything available, we have no buffer
+  return 0;
+}
+
+
+int HalfDuplexSerial::peek(void)
+{
+  // We have no buffer, no peeking
+  return -1;
+}
+
+int HalfDuplexSerial::read(void)
+{
+  #ifdef HALF_DUPLEX_SERIAL_DISABLE_READ
+  return -1;
+  #else
+  return RxByteNBNegOneReturn();
+  #endif
+}
+
+// This is the same as Serial.read() in that it is a
+// non blocking read, returning -1 if no data was read
+int HalfDuplexSerial::read_byte(void)
+{
+  return RxByteNBNegOneReturn();
+}
+
+char HalfDuplexSerial::read_char(void)
+{
+  return RxByteNBZeroReturn();
+}
+
+char HalfDuplexSerial::read_char_blocking(void)
+{
+  cli();
+  return RxByte();
+}
+
+void HalfDuplexSerial::read_str(char buf[], uint8_t length)
+{
+  uint16_t t = 0xFFFF; // every time we attempt to read and fail, we decrement,
+                       // when we hit zero time is up.  FIXME to use a more
+                       // definite timing!
+  uint8_t i = 0;
+  buf[length - 1] = 0; // enforce null termination
+
+  // Caution! There's no buffering in our serial routine, no interrupt driven
+  // collection, so we need to have this loop pretty tight to avoid missed-bits
+  // and corrupted bytes.
+  //
+  // The usefulness of this routine is questionable at best.
+  //
+  // Interrupts are disabled during the entire read
+  uint8_t oldSREG = SREG;
+  cli();
+  do
+  {
+    while( (!(buf[i] = RxByteNBZeroReturn())) && --t);
+  } while((++i < (length-1)) && t);
+  SREG = oldSREG; // Put back interrupts again
+
+  // i ends up as the index of the next character to read
+  // this is at most length-1 so we can simply set i to be
+  // null and we have our null-terminated string
+  buf[i] = 0;
+}
+
+
+size_t HalfDuplexSerial::write(uint8_t ch)
+{
+  TxByte(ch);
+  return 1;
+}
+
+// A non-virtual version, can be optimized out, always available
+size_t HalfDuplexSerial::write_byte(uint8_t ch)
+{
+  TxByte(ch);
+  return 1;
+}
+
+
+HalfDuplexSerial::operator bool()
+{
+  return true;
+}
+
+HalfDuplexSerial Serial;

--- a/avr/cores/microcore/HalfDuplexSerial.h
+++ b/avr/cores/microcore/HalfDuplexSerial.h
@@ -25,17 +25,19 @@
 #include "core_settings.h"
 
 // Set default baud rate based on F_CPU
-#ifndef BAUD_RATE
+#ifndef CUSTOM_BAUD_RATE
   #if F_CPU >= 4800000L
     #define BAUD_RATE  115200
   #elif F_CPU >= 1000000L
     #define BAUD_RATE  38400
   #elif F_CPU >= 600000L
-    #define BAUD_RATE  9600
+    #define BAUD_RATE  19200
   #else
     #define BAUD_RATE  300
     #error Clock speed too slow for serial communication!
   #endif
+#else
+  #define BAUD_RATE CUSTOM_BAUD_RATE
 #endif
 
 #ifdef __cplusplus
@@ -52,16 +54,13 @@ extern "C" {
 }
 #endif
 
-#define STR1(x) #x
-#define STR(x) STR1(x)
-
 #define DIVIDE_ROUNDED(NUMERATOR, DIVISOR) ((((2*(NUMERATOR))/(DIVISOR))+1)/2)
 
-// txbit takes 3*RXDELAY + 15 cycles
-#define BIT_CYCLES DIVIDE_ROUNDED(F_CPU,BAUD_RATE)
+// txbit takes 3*RXDELAY + 7 cycles
+#define BIT_CYCLES DIVIDE_ROUNDED(F_CPU,BAUD_RATE*1L)
 #define TXDELAYCOUNT DIVIDE_ROUNDED(BIT_CYCLES - 7, 3)
 
-#define RXSTART_CYCLES DIVIDE_ROUNDED(3*F_CPU,2*BAUD_RATE)
+#define RXSTART_CYCLES DIVIDE_ROUNDED(3L*F_CPU,2L*BAUD_RATE)
 // 1st bit sampled 3*RXDELAY + 11 cycles after start bit begins
 #define RXSTARTCOUNT DIVIDE_ROUNDED(RXSTART_CYCLES - 13, 3)
 // rxbit takes 3*RXDELAY + 12 cycles

--- a/avr/cores/microcore/HalfDuplexSerial.h
+++ b/avr/cores/microcore/HalfDuplexSerial.h
@@ -1,0 +1,236 @@
+/* optimized half-duplex high-speed serial uart implementation
+ * @author: Ralph Doncaster 2014
+ * @version: $Id$
+ * soft UART has only 0.8% timing error at default 115200 baud rate @8Mhz
+ * and 2.1% timing error at 230400.
+ *
+ * define BAUD_RATE before including HalfDuplexSerial.h to change default baud rate
+ *
+ * Modified by J.Sleeman (sparks@gogo.co.nz) to add Non Blocking reads
+ *   RxByteNBZeroReturn   (returns BYTE 0 for no data [or null byte read])
+ *   RxByteNBNegOneReturn (returns INT -1 for no data)
+ * if not used these should be optimized out automatically by the linker.
+ *
+ * Wrapped in Stream/Print class to be able to use as Serial by J.Sleeman
+ *
+ * Modified by MCUdude for the MicroCore
+ * https://github.com/MCUdude/MicroCore
+ */
+
+#ifndef HalfDuplexSerial_h
+#define HalfDuplexSerial_h
+
+#include "Arduino.h"
+#include "Print.h"
+#include "core_settings.h"
+
+// Set default baud rate based on F_CPU
+#ifndef BAUD_RATE
+  #if F_CPU >= 4800000L
+    #define BAUD_RATE  115200
+  #elif F_CPU >= 1000000L
+    #define BAUD_RATE  38400
+  #elif F_CPU >= 600000L
+    #define BAUD_RATE  9600
+  #else
+    #define BAUD_RATE  300
+    #error Clock speed too slow for serial communication!
+  #endif
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void TxByte(unsigned char);
+  unsigned char RxByte();
+
+  // These two functions are non-blocking variants
+  unsigned char RxByteNBZeroReturn();  // NBZeroReturn will return a zero when there is no byte read
+  int RxByteNBNegOneReturn();          // NBNegOneReturn returns -1; which is the same as standard Serial.write()
+
+#ifdef __cplusplus
+}
+#endif
+
+#define STR1(x) #x
+#define STR(x) STR1(x)
+
+#define DIVIDE_ROUNDED(NUMERATOR, DIVISOR) ((((2*(NUMERATOR))/(DIVISOR))+1)/2)
+
+// txbit takes 3*RXDELAY + 15 cycles
+#define BIT_CYCLES DIVIDE_ROUNDED(F_CPU,BAUD_RATE)
+#define TXDELAYCOUNT DIVIDE_ROUNDED(BIT_CYCLES - 7, 3)
+
+#define RXSTART_CYCLES DIVIDE_ROUNDED(3*F_CPU,2*BAUD_RATE)
+// 1st bit sampled 3*RXDELAY + 11 cycles after start bit begins
+#define RXSTARTCOUNT DIVIDE_ROUNDED(RXSTART_CYCLES - 13, 3)
+// rxbit takes 3*RXDELAY + 12 cycles
+#define RXDELAYCOUNT DIVIDE_ROUNDED(BIT_CYCLES - 13, 3)
+
+#if (RXSTARTCOUNT > 255)
+  #if (F_CPU == 20000000L)
+    #error Baud rate too low for a 20 MHz clock! Use 57600 baud or more
+  #elif (F_CPU == 16000000L)
+    #error Baud rate too low for a 16 MHz clock! Use 38400 baud or more
+  #elif (F_CPU == 12000000L)
+    #error Baud rate too low for a 12 MHz clock! Use 38400 baud or more
+  #elif (F_CPU == 9600000L)
+    #error Baud rate too low for a 9.6 MHz clock! Use 38400 baud or more
+  #elif (F_CPU == 8000000L)
+    #error Baud rate too low for a 16 MHz clock! Use 38400 baud or more
+  #elif (F_CPU == 4800000L)
+    #error Baud rate too low for a 4.8 MHz clock! Use 9600 baud or more
+  #elif (F_CPU == 1200000L)
+    #error Baud rate too low for a 1.2 MHz clock! Use 2400 baud or more
+  #elif (F_CPU == 1000000L)
+    #error Baud rate too low for a 1 MHz clock! Use 2400 baud or more
+  #elif (F_CPU == 600000L)
+    #error Baud rate too low for a 600kHz clock! Use 1200 baud or more
+  #endif
+#endif
+
+asm(".global TXDELAY" );
+asm(".global RXSTART" );
+asm(".global RXDELAY" );
+
+// dummy function defines no code
+// hack to define absolute linker symbols using C macro calculations
+static void dummy() __attribute__ ((naked));
+static void dummy() __attribute__ ((used));
+static void dummy()
+{
+asm (
+    ".equ TXDELAY, %[txdcount]\n"
+    ::[txdcount] "M" (TXDELAYCOUNT)
+    );
+asm (
+    ".equ RXSTART, %[rxscount]\n"
+    ::[rxscount] "M" (RXSTARTCOUNT)
+    );
+asm (
+    ".equ RXDELAY, %[rxdcount]\n"
+    ::[rxdcount] "M" (RXDELAYCOUNT)
+    );
+}
+
+class HalfDuplexSerial : public Print
+{
+  public:
+    void begin(const uint32_t) { } // Does NOTHING, you have no need to call this, here only for compatability
+    void end() { }                 // Does NOTHING, you have no need to call this, here only for compatability
+    int available(void) ;          // As we do not have a buffer, this always returns 0
+    int peek(void)      ;          // As we do not have a buffer, this always returns -1
+    void flush(void) { }           // Does NOTHING, you have no need to call this, here only for compatability
+    operator bool();               // Always returns true
+
+    // Because we define our own write(uint8_t) (which incidentally is the case for EVERYTHING deriving
+    // from stream) we have to pull the other write methods explicityly from Print::
+    // because C++ isn't smart enough to work out that's what we want to do, or maybe it thinks we
+    // are not smart enough to allow it to do that, either way, one of us is not smart enough.
+    using Print::write; // pull in write(str) and write(buf, size) from Print
+
+    /** Read a byte, non-blocking.
+     *
+     * Caution, this is declared virtual in Stream::read() and it will not be optimized out even if not used.
+     *
+     * In order to get around this, we have the
+     * HALF_DUPLEX_SERIAL_DISABLE_READ
+     * define, if defined then read() is disabled by way of always returning -1 which will allow
+     * the assembly code behind it to be optimized away
+     *
+     * @return int  -1 for no-data-read, 0 or greater is the byte read
+     */
+
+    int read(void);
+
+    /** Read a byte, non-blocking, will optimize-out.
+     *
+     * This is exactly the same as read() except that it's not part of Stream:: so it can be
+     * optimized out if unused, as a result it is available for you to use even if you
+     * define HALF_DUPLEX_SERIAL_DISABLE_READ
+     *
+     * @return int  -1 for no-data-read, 0 or greater is the byte read
+     */
+
+    int read_byte(void);
+
+    /** Read a char, non-blocking.
+     *
+     * This is non blocking and returns 0 for no-data-read (OR if the data read was 0)
+     * it is therefore convenient for reading a character into a character array
+     * if(i>=sizeof(buf)-1 || !(buf[i++]=read_char())) break;
+     * (you can insert a retry-timeout in the loop too for that matter)
+     * remember if reading multiple characters, there is NO buffer, there is NO
+     * handshaking, so your loop better be very tight or you will miss characters
+     * or worse, read characters incorrectly by misinterpreting bits
+     *
+     * Optimized out if unused, always available.
+     *
+     * @return char (0 if nothing read or if the data read was 0)
+     */
+
+    char read_char(void);
+
+    /** Read a char, blocking.
+     *
+     * Blocking read of a single char, doesn't return until it has a byte
+     * so would be useful for a single character read where you only want
+     * 1 character and can't continue until you have it (for example, a
+     * menu selection).
+     *
+     * Optimized out if unused, always available.
+     *
+     * @return char (0 if the data read was 0)
+     */
+
+    char read_char_blocking(void);
+
+    /** Read a variable length null terminated string.
+     *
+     * This is more-or-less non-blocking it will time-out after an
+     * (indeterminate, very lazily counted) number of ms of activity.
+     * The timeout is poorly implemented without the use of millis()
+     * to keep code size and memory usage down.
+     *
+     * Because of null-termination the maximum string length is length-1
+     * notice that we do not return the length of the string
+     * it's null-terminated so you can easily work it out if you need to
+     *
+     * @param buf     The character buffer to put the read string into.
+     * @param length  The length (sizeof()) the buffer.
+     */
+
+    void read_str(char buf[], byte length);
+
+    /** Write a byte.
+     *
+     * Caution, this is declared virtual in Print::write() and it will not be optimized out even if not used.
+     *
+     * In order to get around this, we have the
+     * HALF_DUPLEX_SERIAL_DISABLE_WRITE
+     * define, if defined then write() is disabled by way of always returning -1 which will allow
+     * the assembly code behind it to be optimized away.
+     *
+     * However you still can use write_byte() because that can be optimized out.
+     *
+     * @param ch Byte to write.
+     * @return  Always returns 1
+     */
+
+    size_t  write(uint8_t ch);
+
+    /** Write a byte, will optimize out.
+     *
+     * The same as write() except not virtual and so can be optimized out, as a result this is
+     * available for you to use even if you set HALF_DUPLEX_SERIAL_DISABLE_WRITE
+     *
+     * @param ch Byte to write.
+     * @return  Always returns 1
+     */
+
+    size_t write_byte(uint8_t ch);
+
+};
+
+extern HalfDuplexSerial Serial;
+#endif

--- a/avr/cores/microcore/HalfDuplexSerial.h
+++ b/avr/cores/microcore/HalfDuplexSerial.h
@@ -35,7 +35,7 @@
     #define BAUD_RATE  19200
   #else
     #define BAUD_RATE  300
-    #error Clock speed too slow for serial communication!
+    #warning Clock speed too slow for serial communication!
   #endif
 #else
   #define BAUD_RATE CUSTOM_BAUD_RATE

--- a/avr/cores/microcore/HalfDuplexSerial.h
+++ b/avr/cores/microcore/HalfDuplexSerial.h
@@ -24,6 +24,7 @@
 #include "Print.h"
 #include "core_settings.h"
 
+
 // Set default baud rate based on F_CPU
 #ifndef CUSTOM_BAUD_RATE
   #if F_CPU >= 4800000L
@@ -34,7 +35,7 @@
     #define BAUD_RATE  19200
   #else
     #define BAUD_RATE  300
-    #warning 128 kHz oscillator not suited for serial communication!
+    #error Clock speed too slow for serial communication!
   #endif
 #else
   #define BAUD_RATE CUSTOM_BAUD_RATE
@@ -56,11 +57,11 @@ extern "C" {
 
 #define DIVIDE_ROUNDED(NUMERATOR, DIVISOR) ((((2*(NUMERATOR))/(DIVISOR))+1)/2)
 
-// txbit takes 3*RXDELAY + 7 cycles
-#define BIT_CYCLES DIVIDE_ROUNDED(F_CPU,BAUD_RATE*1L)
+// txbit takes 3*RXDELAY + 15 cycles
+#define BIT_CYCLES DIVIDE_ROUNDED(F_CPU,BAUD_RATE*1L) 
 #define TXDELAYCOUNT DIVIDE_ROUNDED(BIT_CYCLES - 7, 3)
 
-#define RXSTART_CYCLES DIVIDE_ROUNDED(3L*F_CPU,2L*BAUD_RATE)
+#define RXSTART_CYCLES DIVIDE_ROUNDED(3*F_CPU,2L*BAUD_RATE) 
 // 1st bit sampled 3*RXDELAY + 11 cycles after start bit begins
 #define RXSTARTCOUNT DIVIDE_ROUNDED(RXSTART_CYCLES - 13, 3)
 // rxbit takes 3*RXDELAY + 12 cycles
@@ -115,11 +116,12 @@ asm (
 class HalfDuplexSerial : public Print
 {
   public:
-    void begin(const uint32_t) { } // Does NOTHING, you have no need to call this, here only for compatability
-    void end() { }                 // Does NOTHING, you have no need to call this, here only for compatability
+    void begin(const uint32_t) { } // Does NOTHING, you have no need to call this, here only for compatibility
+    void begin() { }               // Does NOTHING, you have no need to call this, here only for compatibility
+    void end() { }                 // Does NOTHING, you have no need to call this, here only for compatibility
     int available(void) ;          // As we do not have a buffer, this always returns 0
     int peek(void)      ;          // As we do not have a buffer, this always returns -1
-    void flush(void) { }           // Does NOTHING, you have no need to call this, here only for compatability
+    void flush(void) { }           // Does NOTHING, you have no need to call this, here only for compatibility
     operator bool();               // Always returns true
 
     // Because we define our own write(uint8_t) (which incidentally is the case for EVERYTHING deriving

--- a/avr/cores/microcore/HalfDuplexSerial.h
+++ b/avr/cores/microcore/HalfDuplexSerial.h
@@ -34,7 +34,7 @@
     #define BAUD_RATE  19200
   #else
     #define BAUD_RATE  300
-    #error Clock speed too slow for serial communication!
+    #warning 128 kHz oscillator not suited for serial communication!
   #endif
 #else
   #define BAUD_RATE CUSTOM_BAUD_RATE

--- a/avr/cores/microcore/HalfDuplexSerial.h
+++ b/avr/cores/microcore/HalfDuplexSerial.h
@@ -27,12 +27,14 @@
 
 // Set default baud rate based on F_CPU
 #ifndef CUSTOM_BAUD_RATE
-  #if F_CPU >= 4800000L
+  #if F_CPU >= 5000000L
     #define BAUD_RATE  115200
+  #elif F_CPU >= 4800000L
+    #define BAUD_RATE  57600  
   #elif F_CPU >= 1000000L
-    #define BAUD_RATE  38400
-  #elif F_CPU >= 600000L
     #define BAUD_RATE  19200
+  #elif F_CPU >= 600000L
+    #define BAUD_RATE  9600
   #else
     #define BAUD_RATE  300
     #warning Clock speed too slow for serial communication!

--- a/avr/cores/microcore/Print.cpp
+++ b/avr/cores/microcore/Print.cpp
@@ -1,217 +1,551 @@
 /*
  Print.cpp - Base class that provides print() and println()
  Copyright (c) 2008 David A. Mellis.  All right reserved.
- 
+
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public
  License as published by the Free Software Foundation; either
  version 2.1 of the License, or (at your option) any later version.
- 
+
  This library is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  Lesser General Public License for more details.
- 
+
  You should have received a copy of the GNU Lesser General Public
  License along with this library; if not, write to the Free Software
  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
- 
+
  Modified 23 November 2006 by David A. Mellis
- Modified by John "smeezekitty" for core13
- 
- Modified by MCUdude for MicroCore
+
+ Modified by MCUdude for the MicroCore
  https://github.com/MCUdude/MicroCore
- */
+*/
 
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <math.h>
+#include <avr/pgmspace.h>
 #include "Arduino.h"
-
 #include "Print.h"
 
 // Public Methods //////////////////////////////////////////////////////////////
 
 /* default implementation: may be overridden */
-void Print::write(const char *str)
+size_t Print::write(const uint8_t *buffer, size_t size)
 {
-  while (*str)
-    write(*str++);
+  // Assume that write always returns 1 for a single character
+  // we remove some additions and save a few bytes.
+  //
+  // Note that Hardware, Software and Basic serial all return 1
+  // for character write regardless, so this as a valid assumption
+  // at least in those cases.
+  //
+  // J.Sleeman (sparks@gogo.co.nz)
+
+  for(size_t n = 0; n < size; n++)
+  {
+    write(buffer[n]);
+  }
+  return size;
+
+  /*
+  size_t n = 0;
+  while (size--) {
+    n += write(*buffer++);
+  }
+  return n;
+  */
 }
 
-/* default implementation: may be overridden */
-void Print::write(const uint8_t *buffer, size_t size)
+size_t Print::print(const __FlashStringHelper *ifsh)
 {
-  while (size--)
-    write(*buffer++);
+  PGM_P p = reinterpret_cast<PGM_P>(ifsh);
+  size_t n = 0;
+
+  // This way saves us 4 bytes, again we assume that
+  // write of a single byte always returns 1 (as it does
+  // for all the Serial classes in this core).
+  //
+  // J.Sleeman (sparks@gogo.co.nz)
+
+  do 
+  {
+    unsigned char c = pgm_read_byte(p++);
+    if (c == 0) break;
+    write(c);
+  } while(++n);
+
+  /*
+  while (1) {
+    unsigned char c = pgm_read_byte(p++);
+    if (c == 0) break;
+    if (write(c)) n++;
+    else break;
+  }
+  */
+
+  return n;
 }
 
-void Print::print(const char str[])
+size_t Print::print(const String &s)
 {
-  write(str);
+  size_t n = 0;
+  for (uint16_t i = 0; i < s.length(); i++) 
+  {
+    n += write(s[i]);
+  }
+  return n;
 }
 
-void Print::print(char c, int base)
+size_t Print::print(const char str[])
 {
-  print((long) c, base);
+  return write(str);
 }
 
-void Print::print(unsigned char b, int base)
+// print of a char must always just pass straight to write
+// in order to print the actual character rather than it's value
+size_t Print::print(char c)
 {
-  print((unsigned long) b, base);
+  return write(c);
 }
 
-void Print::print(int n, int base)
+#if PRINT_MAX_INT_TYPE != PRINT_INT_TYPE_BYTE
+size_t Print::print(unsigned char b, uint8_t base)
 {
-  print((long) n, base);
+  return print((UNSIGNED_PRINT_INT_TYPE) b, base);
+}
+#endif
+
+#if PRINT_MAX_INT_TYPE != PRINT_INT_TYPE_INT
+size_t Print::print(int n, uint8_t base)
+{
+  return print((PRINT_INT_TYPE) n, base);
 }
 
-void Print::print(unsigned int n, int base)
+size_t Print::print(unsigned int n, uint8_t base)
 {
-  print((unsigned long) n, base);
+  return print((UNSIGNED_PRINT_INT_TYPE) n, base);
+}
+#endif
+
+#if PRINT_MAX_INT_TYPE != PRINT_INT_TYPE_LONG
+size_t Print::print(long n, uint8_t base)
+{
+  return print((PRINT_INT_TYPE) n, base);
 }
 
-void Print::print(long n, int base)
+size_t Print::print(unsigned long n, uint8_t base)
 {
-  if (base == 0) {
-    write(n);
-  } else if (base == 10) {
-    if (n < 0) {
-      print('-');
+  return print((UNSIGNED_PRINT_INT_TYPE) n, base);
+}
+#endif
+
+size_t Print::print(PRINT_INT_TYPE n, uint8_t base)
+{
+  /* Optimisation - not testing for invalid base
+   * saves us some bytes, printNumber will "promote"
+   * it to a valid base (2) anyway.
+   *
+   * The long-winded negative sign for base 10
+   * is simplified to remove the temporary variable
+   * sames us some more bytes
+   *
+   * I get 46 bytes less flash usage with mine.  On a tiny13
+   * that's MASSIVE!
+   *
+   * J.Sleeman (sparks@gogo.co.nz)
+   */
+
+  /*
+
+  if (base == 0)
+  {
+    return write(n);
+  } 
+  else if (base == 10)
+  {
+    int t = 0;
+    if (n < 0)
+    {
+      t = print('-');
       n = -n;
     }
-    printNumber(n, 10);
-  } else {
-    printNumber(n, base);
+    return printNumber(n, 10) + t;
+  }
+  */
+
+  if (base == 10 && n < 0)
+  {
+    // Interesting, this single liner makes it 16 bytes larger
+    // than the 2 lines.
+    //    return write('-') + printNumber(-n,base);
+    write('-');
+    return printNumber(-n,base)+1;
+  }
+  else
+  {
+    return printNumber(n, base);
   }
 }
 
-void Print::print(unsigned long n, int base)
+size_t Print::print(UNSIGNED_PRINT_INT_TYPE n, uint8_t base)
 {
-  if (base == 0) write(n);
-  else printNumber(n, base);
+  /* As above, invalid base gets promoted in printNumber()
+   * no need to look for it here.
+
+  if (base == 0) return write(n);
+  else return printNumber(n, base);
+  */
+  return printNumber(n,base);
 }
 
-/*
-void Print::print(double n, int digits)
+size_t Print::print(double n, uint8_t digits)
 {
-  printFloat(n, digits);
+  return printFloat(n, digits);
 }
-*/
-void Print::println(void)
+
+size_t Print::println(const __FlashStringHelper *ifsh)
 {
+  size_t n = print(ifsh);
+  n += println();
+  return n;
+}
+
+size_t Print::println(void)
+{
+  // I'm gonna assume that printing a single character
+  // is only every going to return 1, so we don't need
+  // to keep track of this, saves us 10 bytes of flash
+  //
+  // Note that this is true for Hardware,TinySoftware
+  // and Basic Serial classes, they all blindly return
+  // 1 as the result of a ::write(byte) regardless if
+  // there is any notion of "success" or not.
+  //
+  // J.Sleeman (sparks@gogo.co.nz)
+  //
+
+  /*
+  size_t n = print('\r');
+  n += print('\n');
+  return n;
+  */
+
   print('\r');
-  print('\n');  
+  print('\n');
+  return 2;
 }
 
-void Print::println(const char c[])
+size_t Print::println(const String &s)
 {
-  print(c);
-  println();
+  size_t n = print(s);
+  n += println();
+  return n;
 }
 
-void Print::println(char c, int base)
+size_t Print::println(const char c[])
 {
-  print(c, base);
-  println();
+  size_t n = print(c);
+  n += println();
+  return n;
 }
 
-void Print::println(unsigned char b, int base)
+size_t Print::println(char c)
 {
-  print(b, base);
-  println();
+  size_t n = print(c);
+  n += println();
+  return n;
+}
+#if PRINT_MAX_INT_TYPE != PRINT_INT_TYPE_BYTE
+size_t Print::println(unsigned char b, uint8_t base)
+{
+  size_t n = print(b, base);
+  n += println();
+  return n;
+}
+#endif
+#if PRINT_MAX_INT_TYPE != PRINT_INT_TYPE_INT
+size_t Print::println(int num, uint8_t base)
+{
+  size_t n = print(num, base);
+  n += println();
+  return n;
 }
 
-void Print::println(int n, int base)
+size_t Print::println(unsigned int num, uint8_t base)
 {
-  print(n, base);
-  println();
+  size_t n = print(num, base);
+  n += println();
+  return n;
+}
+#endif
+#if PRINT_MAX_INT_TYPE != PRINT_INT_TYPE_LONG
+size_t Print::println(long num, uint8_t base)
+{
+  size_t n = print(num, base);
+  n += println();
+  return n;
 }
 
-void Print::println(unsigned int n, int base)
+size_t Print::println(unsigned long num, uint8_t base)
 {
-  print(n, base);
-  println();
+  size_t n = print(num, base);
+  n += println();
+  return n;
+}
+#endif
+size_t Print::println(PRINT_INT_TYPE num, uint8_t base)
+{
+  size_t n = print(num, base);
+  n += println();
+  return n;
 }
 
-void Print::println(long n, int base)
+size_t Print::println(UNSIGNED_PRINT_INT_TYPE num, uint8_t base)
 {
-  print(n, base);
-  println();
+  size_t n = print(num, base);
+  n += println();
+  return n;
 }
 
-void Print::println(unsigned long n, int base)
+size_t Print::println(double num, int digits)
 {
-  print(n, base);
-  println();
+  size_t n = print(num, digits);
+  n += println();
+  return n;
 }
-
-/*
-void Print::println(double n, int digits)
-{
-  print(n, digits);
-  println();
-}
-*/
 
 // Private Methods /////////////////////////////////////////////////////////////
 
-void Print::printNumber(unsigned long n, uint8_t base)
+
+#ifndef PRINT_USE_BASE_ARBITRARY
+
+// This is a more memory (RAM and FLASH) efficient printNumber implementation
+// for very low ram machines, eg tiny13, the original was way too big
+// for several reasons...
+//
+// 1. It uses unsigned long
+// 2. It uses division (an expensive operation on attiny)
+// 3. It uses a character buffer of effectively 33 bytes
+//    in order to build the number before writing it out
+//
+// When you only have 64 bytes of ram in the first place, that doesn't end well.
+//
+// This produces smaller flash and sram, even though it looks bigger with all these lookup tables
+// the reduction in the number of assembly instructions more than makes up for it.
+//
+// Credit goes to EEVBlog User "Kalvin"
+//  http://www.eevblog.com/forum/microcontrollers/memory-efficient-int-to-chars-without-division-(bitshift-ok)-for-binary-bases/msg805172/#msg805172
+//
+// The only downside is that it can't do arbitrary bases, just 2, 8, 16 and 10
+//
+// In your pins_arduino.h you will want to set
+//
+//  #define PRINT_USE_BASE_BIN
+//  #define PRINT_USE_BASE_HEX
+//  #define PRINT_USE_BASE_OCT
+//  #define PRINT_USE_BASE_DEC
+//
+// if you define PRINT_USE_BASE_ARBITRARY then this function will not be used
+// it will suck your ram, but you can use arbitrary bases.
+
+
+size_t Print::printNumber(UNSIGNED_PRINT_INT_TYPE n, uint8_t base)
 {
-  unsigned char buf[8 * sizeof(long)]; // Assumes 8-bit chars. 
-  unsigned long i = 0;
+  static const char digits[] PROGMEM = "0123456789ABCDEF";
 
-  if (n == 0) {
-    print('0');
-    return;
-  } 
+  #if defined(PRINT_USE_BASE_BIN)
+  static const UNSIGNED_PRINT_INT_TYPE base2[]  PROGMEM =
+  {
+    #if PRINT_MAX_INT_TYPE == PRINT_INT_TYPE_LONG
+        0x80000000, 0x40000000, 0x20000000, 0x10000000,  0x800000, 0x400000, 0x200000, 0x100000, 0x80000, 0x40000, 0x20000, 0x10000,
+    #endif
+    #if (PRINT_MAX_INT_TYPE == PRINT_INT_TYPE_LONG) || (PRINT_MAX_INT_TYPE == PRINT_INT_TYPE_INT)
+      0x8000, 0x4000, 0x2000, 0x1000, 0x800, 0x400, 0x200, 0x100,
+    #endif
+      0x80, 0x40, 0x20, 0x10, 0x8, 0x4, 0x2, 0x1, 0
+  };
+  #endif
+  #if defined(PRINT_USE_BASE_OCT)
+  static const UNSIGNED_PRINT_INT_TYPE base8[]  PROGMEM =
+  {
+    #if PRINT_MAX_INT_TYPE == PRINT_INT_TYPE_LONG
+      010000000000, 01000000000, 0100000000, 010000000, 01000000,
+    #endif
+    #if (PRINT_MAX_INT_TYPE == PRINT_INT_TYPE_LONG) || (PRINT_MAX_INT_TYPE == PRINT_INT_TYPE_INT)
+      0100000, 010000,  01000,
+    #endif
+      0100, 010, 01,
+      0
+  };
+  #endif
+  #if defined(PRINT_USE_BASE_DEC)
+  static const UNSIGNED_PRINT_INT_TYPE base10[] PROGMEM =
+  {
+    #if PRINT_MAX_INT_TYPE == PRINT_INT_TYPE_LONG
+      1000000000,100000000,10000000,1000000,100000,
+    #endif
+    #if (PRINT_MAX_INT_TYPE == PRINT_INT_TYPE_LONG) || (PRINT_MAX_INT_TYPE == PRINT_INT_TYPE_INT)
+      10000,  1000,
+    #endif
+      100,    10,  1,
+      0
+  };
+  #endif
+  #if defined(PRINT_USE_BASE_HEX)
+  static const UNSIGNED_PRINT_INT_TYPE base16[] PROGMEM =
+  {
+    #if PRINT_MAX_INT_TYPE == PRINT_INT_TYPE_LONG
+      0x10000000, 0x1000000,
+        0x100000,  0x010000,
+    #endif
+    #if (PRINT_MAX_INT_TYPE == PRINT_INT_TYPE_LONG) || (PRINT_MAX_INT_TYPE == PRINT_INT_TYPE_INT)
+          0x1000,    0x0100,
+    #endif
+            0x10,      0x01,
+                          0
+  };
+  #endif
 
-  while (n > 0) {
-    buf[i++] = n % base;
-    n /= base;
+  UNSIGNED_PRINT_INT_TYPE const * bt;
+  uint8_t leadingzero = 0;
+  switch(base)
+  {
+    default:
+      #if defined(PRINT_USE_BASE_HEX)
+        write('x');
+        base = 16;
+        __attribute__ ((fallthrough)); // Mute fall through warning
+      #elif defined(PRINT_USE_BASE_DEC)
+        write('d');
+        base = 10;
+        __attribute__ ((fallthrough)); // Mute fall through warning
+      #elif defined(PRINT_USE_BASE_OCT)
+        write('o');
+        base = 8;
+        __attribute__ ((fallthrough)); // Mute fall through warning
+      #elif defined(PRINT_USE_BASE_BIN)
+        write('b');
+        base = 2;
+        __attribute__ ((fallthrough)); // Mute fall through warning
+      #endif
+
+      #ifdef PRINT_USE_BASE_HEX
+        case 16: bt = base16; break;
+      #endif
+      #ifdef PRINT_USE_BASE_DEC
+        case 10: bt = base10; break;
+      #endif
+      #ifdef PRINT_USE_BASE_OCT
+        case 8:  bt = base8;  break;
+      #endif
+      #ifdef PRINT_USE_BASE_BIN
+        case 2:  bt = base2;  break;
+      #endif
   }
 
-  for (; i > 0; i--)
-    print((char) (buf[i - 1] < 10 ?
-      '0' + buf[i - 1] :
-      'A' + buf[i - 1] - 10));
+  // Reuse base for counting the digits since we don't need it any more.
+  base = 0;
+  do
+  {
+    UNSIGNED_PRINT_INT_TYPE b = PGM_READ_MAX_INT_TYPE(&*bt++);
+    uint8_t digit = 0;
+    while (n >= b)
+    {
+      digit++;
+      n = n - b;
+    }
+    leadingzero = leadingzero ? leadingzero : digit;
+    if (b == 1 || leadingzero)
+    {
+      ++base;
+      write(pgm_read_byte(&digits[digit]));
+    }
+  }
+  while (PGM_READ_MAX_INT_TYPE(&*bt));
+  return base;
 }
 
-/*
-void Print::printFloat(double number, uint8_t digits) 
+
+#else
+
+// This is the original printNumber from Arduino with just the small change to
+// allow you to set the integer type in use (see Print.h for how to set
+// PRINT_MAX_INT_TYPE for your requirements in pins_arduino.h).
+//
+// This function allows arbitrary bases, but is very VERY heavy especially
+// if you are not using division anywhere else in your program.
+//
+// VERY, VERY HEAVY
+
+size_t Print::printNumber(UNSIGNED_PRINT_INT_TYPE n, uint8_t base)
 {
- 
+
+  // This is super wasteful because it assumes you are using binary in the
+  // worst case and makes a buffer big enough to show it in binary
+  // which is 1 byte per bit
+  char buf[8 * sizeof(n) + 1]; // Assumes 8-bit chars plus zero byte.
+
+  char *str = &buf[sizeof(buf) - 1];
+
+  *str = '\0';
+
+  // prevent crash if called with base == 1
+  if (base < 2) base = 10;
+
+  do
+  {
+    UNSIGNED_PRINT_INT_TYPE m = n;
+    n /= base;
+    char c = m - base * n;
+    *--str = c < 10 ? c + '0' : c + 'A' - 10;
+  } while(n);
+
+  return write(str);
+}
+#endif
+
+size_t Print::printFloat(double number, uint8_t digits)
+{
+  size_t n = 0;
+
   // Handle negative numbers
   if (number < 0.0)
   {
-     print('-');
+     n += print('-');
      number = -number;
   }
 
   // Round correctly so that print(1.999, 2) prints as "2.00"
   double rounding = 0.5;
   for (uint8_t i=0; i<digits; ++i)
+  {
     rounding /= 10.0;
-  
+  }
+
   number += rounding;
 
   // Extract the integer part of the number and print it
   unsigned long int_part = (unsigned long)number;
   double remainder = number - (double)int_part;
-  print(int_part);
+  n += print(int_part);
 
   // Print the decimal point, but only if there are digits beyond
   if (digits > 0)
-    print("."); 
+  {
+    n += print('.');
+  }
 
   // Extract digits from the remainder one at a time
   while (digits-- > 0)
   {
     remainder *= 10.0;
     int toPrint = int(remainder);
-    print(toPrint);
-    remainder -= toPrint; 
-  } 
+    n += print(toPrint);
+    remainder -= toPrint;
+  }
+
+  return n;
 }
-*/

--- a/avr/cores/microcore/Print.cpp
+++ b/avr/cores/microcore/Print.cpp
@@ -417,33 +417,33 @@ size_t Print::printNumber(UNSIGNED_PRINT_INT_TYPE n, uint8_t base)
       #if defined(PRINT_USE_BASE_HEX)
         write('x');
         base = 16;
-        __attribute__ ((fallthrough)); // Mute fall through warning
       #elif defined(PRINT_USE_BASE_DEC)
         write('d');
         base = 10;
-        __attribute__ ((fallthrough)); // Mute fall through warning
       #elif defined(PRINT_USE_BASE_OCT)
         write('o');
         base = 8;
-        __attribute__ ((fallthrough)); // Mute fall through warning
       #elif defined(PRINT_USE_BASE_BIN)
         write('b');
         base = 2;
-        __attribute__ ((fallthrough)); // Mute fall through warning
       #endif
 
-      #ifdef PRINT_USE_BASE_HEX
-        case 16: bt = base16; break;
-      #endif
-      #ifdef PRINT_USE_BASE_DEC
-        case 10: bt = base10; break;
-      #endif
-      #ifdef PRINT_USE_BASE_OCT
-        case 8:  bt = base8;  break;
-      #endif
-      #ifdef PRINT_USE_BASE_BIN
-        case 2:  bt = base2;  break;
-      #endif
+    #ifdef PRINT_USE_BASE_HEX
+      // Fall through
+      case 16: bt = base16; break;
+    #endif
+    #ifdef PRINT_USE_BASE_DEC
+      // Fall through
+      case 10: bt = base10; break;
+    #endif
+    #ifdef PRINT_USE_BASE_OCT
+      // Fall through
+      case 8:  bt = base8;  break;
+    #endif
+    #ifdef PRINT_USE_BASE_BIN
+      // Fall through
+      case 2:  bt = base2;  break;
+    #endif
   }
 
   // Reuse base for counting the digits since we don't need it any more.

--- a/avr/cores/microcore/Print.h
+++ b/avr/cores/microcore/Print.h
@@ -15,9 +15,9 @@
   You should have received a copy of the GNU Lesser General Public
   License along with this library; if not, write to the Free Software
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
-  
-  Modified by John "smeezekitty" for core13
-  
+
+  Modified 20-11-2010 by B.Cook ...
+
   Modified by MCUdude for the MicroCore
   https://github.com/MCUdude/MicroCore
 */
@@ -27,8 +27,8 @@
 
 #include <inttypes.h>
 #include <stdio.h> // for size_t
-
-
+#include "WString.h"
+#include "core_settings.h"
 
 #define DEC 10
 #define HEX 16
@@ -36,36 +36,191 @@
 #define BIN 2
 #define BYTE 0
 
+// Maximum integer type to be handled.
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+//
+// For small machines (tiny13 etc) handling long may be too demanding
+// so we can now specify that int is the largest type we can handle
+//
+// In other words, put this in your pins_arduino.h file...
+//    #define PRINT_MAX_INT_TYPE PRINT_INT_TYPE_INT
+// (or pass in buld.extra_flags=-DPRINT_MAX_INT_TYPE=2)
+//
+// The possible options are exactly these:
+//
+// PRINT_INT_TYPE_LONG  (default)
+// PRINT_INT_TYPE_INT
+// PRINT_INT_TYPE_BYTE
+//
+//
+
+#define PRINT_INT_TYPE_LONG 1
+#define PRINT_INT_TYPE_INT  2
+#define PRINT_INT_TYPE_BYTE 3
+
+#ifndef PRINT_MAX_INT_TYPE
+  // The official Arduino core can do long, so this is the default
+  // if your variant doesn't specify otherwise.
+  #define PRINT_MAX_INT_TYPE    PRINT_INT_TYPE_LONG
+#endif
+
+#if PRINT_MAX_INT_TYPE == PRINT_INT_TYPE_LONG
+  #define PRINT_INT_TYPE            int32_t
+  #define UNSIGNED_PRINT_INT_TYPE   uint32_t
+  #define PGM_READ_MAX_INT_TYPE(A)  pgm_read_dword(A)
+#elif PRINT_MAX_INT_TYPE == PRINT_INT_TYPE_INT
+  #define PRINT_INT_TYPE            int16_t
+  #define UNSIGNED_PRINT_INT_TYPE   uint16_t
+  #define PGM_READ_MAX_INT_TYPE(A)  pgm_read_word(A)
+#elif PRINT_MAX_INT_TYPE == PRINT_INT_TYPE_BYTE
+  #define PRINT_INT_TYPE            int8_t
+  #define UNSIGNED_PRINT_INT_TYPE   uint8_t
+  #define PGM_READ_MAX_INT_TYPE(A)  pgm_read_byte(A)
+#endif
+
+
+// Number Base printing support
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+//
+// Tight memory systems (flash and sram) might need to restrict the number
+// bases that can be printed, typically it's unnecessary
+// to allow arbitrary bases and doing so really eats your sram (and flash).
+//
+// Set one or more of the following defines (in pins_arduino.h usually):
+//
+//   #define PRINT_USE_BASE_BIN
+//   #define PRINT_USE_BASE_HEX
+//   #define PRINT_USE_BASE_OCT
+//   #define PRINT_USE_BASE_DEC
+//   #define PRINT_USE_BASE_ARBITRARY
+//
+// if PRINT_USE_BASE_ARBITRARY is set the other defines are ignored
+// and the normal Arduino print functions are in play.
+//
+// if it is not set then an optimised printNumber() function is used
+// without division.
+//
+// If nothing is set then we use the following as the default:
+//
+// #define PRINT_USE_BASE_BIN
+// #define PRINT_USE_BASE_HEX
+// #define PRINT_USE_BASE_OCT
+// #define PRINT_USE_BASE_DEC
+//
+// This gives us almost the same functionality as the standard
+// arduino print, because 99% of people are only ever going to need
+// base 2/8/10 and 16 in their life (frankly, I would omit 8 as well
+// except that ASCIITable example uses it).
+//
+// If you try and print an "unsupported" base it's not a problem
+// simply it will "promote" your request to the highest supported
+// base and prefix the printed number with a letter to signal
+// (b = binary, o = octal, d = decimal, x = hex)
+// which base was used instead of what you requested.
+//
+// If you really want to use non-standard bases, set PRINT_USE_BASE_ARBITRARY
+// but be aware that it will bring in a very large amount of overhead
+// (mainly ram usage, not good if you only have 64 bytes of RAM!)
+//
+// For what it's worth the flash-usage for having only ONE base
+// enabled was measured on a sketch as follows...
+//
+// BIN      = lowest
+// OCT      = 6 bytes more than BIN only
+// HEX      = 6 bytes more than BIN only
+// DEC      = highest - 22 bytes more than BIN
+//
+// Some combinations relative to BIN only:
+// BIN+OCT         = +36 bytes
+// BIN+HEX         = +52 bytes
+// BIN+HEX+OCT     = +72 bytes
+// BIN+DEC         = +94 bytes
+// DEC+HEX         = +98 bytes
+// BIN+HEX+DEC     = +122 bytes
+// BIN+HEX+DEC+OCT = +150 bytes
+//
+// Short version, if you can live with only one supported base
+// for printing numbers, you save a whole pile of memory no matter
+// which base you choose, even DEC on it's own doesn't eat much
+// more than BIN on it's own, but as soon as you start supporting
+// more than one base, you start eating flash.
+//
+// Of course, if you don't actually use anything that calls
+//    print(numberhere, [optionalbase])
+// then it's all optimised away by gcc and you don't care.
+//
+
+#if ! (defined(PRINT_USE_BASE_BIN) || defined(PRINT_USE_BASE_HEX) || defined(PRINT_USE_BASE_OCT) || defined(PRINT_USE_BASE_DEC) || defined(PRINT_USE_BASE_ARBITRARY))
+  #define PRINT_USE_BASE_BIN
+  #define PRINT_USE_BASE_HEX
+  #define PRINT_USE_BASE_OCT
+  #define PRINT_USE_BASE_DEC
+#endif
+
 class Print
 {
   private:
-    void printNumber(unsigned long, uint8_t);
-//    void printFloat(double, uint8_t);
-  public:
-    virtual void write(uint8_t) = 0;
-    virtual void write(const char *str);
-    virtual void write(const uint8_t *buffer, size_t size);
-    
-//    void print(const String &);
-    void print(const char[]);
-    void print(char, int = BYTE);
-    void print(unsigned char, int = BYTE);
-    void print(int, int = DEC);
-    void print(unsigned int, int = DEC);
-    void print(long, int = DEC);
-    void print(unsigned long, int = DEC);
-//    void print(double, int = 2);
+    int write_error;
 
-//    void println(const String &s);
-    void println(const char[]);
-    void println(char, int = BYTE);
-    void println(unsigned char, int = BYTE);
-    void println(int, int = DEC);
-    void println(unsigned int, int = DEC);
-    void println(long, int = DEC);
-    void println(unsigned long, int = DEC);
-//    void println(double, int = 2);
-    void println(void);
+    size_t printNumber(UNSIGNED_PRINT_INT_TYPE, uint8_t);
+    size_t printFloat(double, uint8_t);
+  protected:
+    void setWriteError(int err = 1) { write_error = err; }
+  public:
+    Print() : write_error(0) {}
+
+    int getWriteError() { return write_error; }
+    void clearWriteError() { setWriteError(0); }
+
+    virtual size_t write(uint8_t) = 0;
+    size_t write(const char *str) { return write((const uint8_t *)str, strlen(str)); }
+    virtual size_t write(const uint8_t *buffer, size_t size);
+
+    size_t print(const __FlashStringHelper *);
+    size_t print(const String &);
+    size_t print(const char[]);
+    size_t print(char);
+
+    // by using these conditionals we can cut-out some pointless
+    // function calls and casting when our "primary" integer type
+    // for print is the same as that particular function handles
+    // otherwise these guarded functions will cast to the
+    // primary type (PRINT_INT_TYPE or UNSIGNED_PRINT_INT_TYPE
+    // as appropriate).
+    #if PRINT_MAX_INT_TYPE != PRINT_INT_TYPE_BYTE
+    size_t print(unsigned char, uint8_t = DEC);
+    #endif
+    #if PRINT_MAX_INT_TYPE != PRINT_INT_TYPE_INT
+    size_t print(int, uint8_t = DEC);
+    size_t print(unsigned int, uint8_t = DEC);
+    #endif
+    #if PRINT_MAX_INT_TYPE != PRINT_INT_TYPE_LONG
+    size_t print(long, uint8_t = DEC);
+    size_t print(unsigned long, uint8_t = DEC);
+    #endif
+    size_t print(PRINT_INT_TYPE, uint8_t = DEC);
+    size_t print(UNSIGNED_PRINT_INT_TYPE, uint8_t = DEC);
+    size_t print(double, uint8_t = 2);
+
+    size_t println(const __FlashStringHelper *);
+    size_t println(const String &s);
+    size_t println(const char[]);
+    size_t println(char);
+    #if PRINT_MAX_INT_TYPE != PRINT_INT_TYPE_BYTE
+    size_t println(unsigned char, uint8_t = DEC);
+    #endif
+    #if PRINT_MAX_INT_TYPE != PRINT_INT_TYPE_INT
+    size_t println(int, uint8_t = DEC);
+    size_t println(unsigned int, uint8_t = DEC);
+    #endif
+    #if PRINT_MAX_INT_TYPE != PRINT_INT_TYPE_LONG
+    size_t println(long, uint8_t = DEC);
+    size_t println(unsigned long, uint8_t = DEC);
+    #endif
+    size_t println(PRINT_INT_TYPE, uint8_t = DEC);
+    size_t println(UNSIGNED_PRINT_INT_TYPE, uint8_t = DEC);
+    size_t println(double, int = 2);
+    size_t println(void);
 };
 
 #endif

--- a/avr/cores/microcore/Print.h
+++ b/avr/cores/microcore/Print.h
@@ -30,11 +30,11 @@
 #include "WString.h"
 #include "core_settings.h"
 
-#define DEC 10
-#define HEX 16
-#define OCT 8
-#define BIN 2
-#define BYTE 0
+#define DEC  ((uint8_t) 10)
+#define HEX  ((uint8_t) 16)
+#define OCT  ((uint8_t)  8)
+#define BIN  ((uint8_t)  2)
+#define BYTE ((uint8_t)  0)
 
 // Maximum integer type to be handled.
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/avr/cores/microcore/core_settings.h
+++ b/avr/cores/microcore/core_settings.h
@@ -26,22 +26,23 @@ need in order to free up space.
 //#define PRINT_USE_BASE_OCT
 
 // Baudrate is automatically selected based on F_CPU. If a different speed is needed, BAUD_RATE can be defined
-// to reflect this. See table below for all supported baud rates.
+// to reflect this.
+// See table below for all supported baud rates.
 
-//#define BAUD_RATE 38400
+//#define CUSTOM_BAUD_RATE 9600
 
-// | Clock & baud | 460800 | 250000 | 230400 | 115200   | 57600 | 38400    | 19200 | 9600     | 4800 | 2400 | 1200 |
-// |--------------|--------|--------|--------|----------|-------|----------|-------|----------|------|------|------|
-// | 20 MHz       | X      | X      | X      | X (def.) | X     |          |       |          |      |      |      |
-// | 16 MHz       | X      | X      | X      | X (def.) | X     | X        |       |          |      |      |      |
-// | 12 MHz       |        | X      | X      | X (def.) | X     | X        |       |          |      |      |      |
-// | 9.6 MHz      |        | X      | X      | X (def.) | X     | X        |       |          |      |      |      |
-// | 8 MHz        |        | X      | X      | X (def.) | X     | X        |       |          |      |      |      |
-// | 4.8 MHz      |        |        |        | X (def.) | X     | X        |       | X        |      |      |      |
-// | 1.2 MHz      |        |        |        |          |       | X (def.) |       | X        | X    | X    |      |
-// | 1 MHz        |        |        |        |          |       | X (def.) |       | X        | X    | X    |      |
-// | 600 kHz      |        |        |        |          |       |          |       | X (def.) | X    | X    | X    |
-// | 128 kHz      |        |        |        |          |       |          |       |          |      |      |      |
+// | Clock & baud | 460800 | 250000 | 230400 | 115200   | 57600 | 38400    | 19200L   | 9600 | 4800 | 2400 | 1200 |
+// |--------------|--------|--------|--------|----------|-------|----------|----------|------|------|------|------|
+// | 20 MHz       | X      | X      | X      | X (def.) | X     |          |          |      |      |      |      |
+// | 16 MHz       | X      | X      | X      | X (def.) | X     | X        |          |      |      |      |      |
+// | 12 MHz       |        | X      | X      | X (def.) | X     | X        |          |      |      |      |      |
+// | 9.6 MHz      |        | X      | X      | X (def.) | X     | X        |          |      |      |      |      |
+// | 8 MHz        |        | X      | X      | X (def.) | X     | X        |          |      |      |      |      |
+// | 4.8 MHz      |        |        |        | X (def.) | X     | X        | X        | X    |      |      |      |
+// | 1.2 MHz      |        |        |        |          |       | X (def.) | X        | X    | X    | X    |      |
+// | 1 MHz        |        |        |        |          |       | X (def.) | X        | X    | X    | X    |      |
+// | 600 kHz      |        |        |        |          |       |          | X (def.) | X    | X    | X    | X    |
+// | 128 kHz      |        |        |        |          |       |          |          |      |      |      |      |
 
 
 // Makes the core "idiot proof" (see wiring_digital.c and wiring_pwm.h for examples where SAFEMODE is used).

--- a/avr/cores/microcore/core_settings.h
+++ b/avr/cores/microcore/core_settings.h
@@ -6,33 +6,50 @@ https://github.com/MCUdude/MicroCore
 This file lets you turn core functions on and off.
 Since the ATtiny13 is really short on space, you
 might want to disable some functions you don't
-need, in order to free up some space.
+need in order to free up space.
 */
 
 #ifndef core_settings_h
 #define core_settings_h
 
+// These defintions is used when compiling Serial printing. Serial is bitbanged, and may be tuned here
+// to reduce the compiled size. The default settings allows you to do pretty much exactly what an "ordinary"
+// Arduino would support.
 
-// If you're not using millis(), you can save about 100b by commenting this out.
-// Note that the millis() interrupt is based on the watch dog timer, and will interrupt
-// every 16th ms (which is very little. This means the millis() function will not be 
-// accurate down to 1 ms, but will increase with steps of 16.
-// NOTE THAT THIS MACRO CAN BE OVERRIDDEN IN ARDUINO IDE
-//#define ENABLE_MILLIS
+// What should be the largest supported number?
+#define PRINT_MAX_INT_TYPE PRINT_INT_TYPE_LONG // PRINT_INT_TYPE_INT, PRINT_INT_TYPE_BYTE and PRINT_INT_TYPE_LONG supported.
 
-// Enabling micros() will cause the processor to interrupt more often (every 2048th clock cycle if 
-// F_CPU < 4.8 MHz, every 16384th clock cycle if F_CPU >= 4.8 MHz. This will add some overhead when F_CPU is
-// less than 4.8 MHz. It's disabled by default because it occupies precious flash space and loads the CPU with
-// additional interrupts and calculations. Also note that micros() aren't very precise for frequencies that 64
-// doesn't divide evenly by.
-// NOTE THAT THIS MACRO CAN BE OVERRIDDEN IN ARDUINO IDE
-//#define ENABLE_MICROS
+// What bases should be supported?
+#define PRINT_USE_BASE_BIN
+#define PRINT_USE_BASE_DEC
+#define PRINT_USE_BASE_HEX
+//#define PRINT_USE_BASE_OCT
+
+// Baudrate is automatically selected based on F_CPU. If a different speed is needed, BAUD_RATE can be defined
+// to reflect this. See table below for all supported baud rates.
+
+//#define BAUD_RATE 38400
+
+// | Clock & baud | 460800 | 250000 | 230400 | 115200   | 57600 | 38400    | 19200 | 9600     | 4800 | 2400 | 1200 |
+// |--------------|--------|--------|--------|----------|-------|----------|-------|----------|------|------|------|
+// | 20 MHz       | X      | X      | X      | X (def.) | X     |          |       |          |      |      |      |
+// | 16 MHz       | X      | X      | X      | X (def.) | X     | X        |       |          |      |      |      |
+// | 12 MHz       |        | X      | X      | X (def.) | X     | X        |       |          |      |      |      |
+// | 9.6 MHz      |        | X      | X      | X (def.) | X     | X        |       |          |      |      |      |
+// | 8 MHz        |        | X      | X      | X (def.) | X     | X        |       |          |      |      |      |
+// | 4.8 MHz      |        |        |        | X (def.) | X     | X        |       | X        |      |      |      |
+// | 1.2 MHz      |        |        |        |          |       | X (def.) |       | X        | X    | X    |      |
+// | 1 MHz        |        |        |        |          |       | X (def.) |       | X        | X    | X    |      |
+// | 600 kHz      |        |        |        |          |       |          |       | X (def.) | X    | X    | X    |
+// | 128 kHz      |        |        |        |          |       |          |       |          |      |      |      |
+
 
 // Makes the core "idiot proof" (see wiring_digital.c and wiring_pwm.h for examples where SAFEMODE is used).
-// Enabling SAFEMODE takes up more flash space, but "makes sure" you don't screw up, like by reading the 
+// Enabling SAFEMODE takes up more flash space, but "makes sure" you don't screw up, like by reading the
 // state of a pin while it's outputting a PWM signal. If you know what you're doing, like explicitly writing
 // a pin as an output before using the analogWrite() function, you can save a lot of space by disabling this.
-#define SAFEMODE 
+#define SAFEMODE
+
 
 // This is the ADC settings
 // Here the ADC prescaler can be changed if needed.
@@ -46,12 +63,14 @@ need, in order to free up some space.
 //#define ADC_PRESCALER_64    // ADC sample rate = (F_CPU/13) / 64
 //#define ADC_PRESCALER_128   // ADC sample rate = (F_CPU/13) / 128
 
+
 // If you're not using the PWM or want to set it up yourself, you can disable it here
 #define SETUP_PWM
 
+
 // Here's the PWM settings for Timer0
 // These settings will also be disabled if SETUP_PWM is commented out
-// Note that ENABLE_MICROS will override this setting 
+// Note that ENABLE_MICROS will override this setting
 #define PWM_PRESCALER_AUTO    // Selects the "best suited" prescaler based on F_CPU
 //#define PWM_PRESCALER_NONE  // PWM frequency = (F_CPU/256) / 1
 //#define PWM_PRESCALER_8     // PWM frequency = (F_CPU/256) / 8
@@ -59,9 +78,26 @@ need, in order to free up some space.
 //#define PWM_PRESCALER_256   // PWM frequency = (F_CPU/256) / 256
 //#define PWM_PRESCALER_1024  // PWM frequency = (F_CPU/256) / 1024
 
+
 // These are the waveform generation settings for timer0
 #define PWM_FAST          //  <-- DEFAULT
 //#define PWM_PHASE_CORRECT
 
+
+// If you're not using millis(), you can save about 100 bytes by commenting this out.
+// Note that the millis() interrupt is based on the watch dog timer, and will interrupt
+// every 16th ms (which is very little. This means the millis() function will not be
+// accurate down to 1 ms, but will increase with steps of 16.
+// NOTE THAT THIS MACRO CAN BE OVERRIDDEN IN ARDUINO IDE TOOLS MENU
+//#define ENABLE_MILLIS
+
+
+// Enabling micros() will cause the processor to interrupt more often (every 2048th clock cycle if
+// F_CPU < 4.8 MHz, every 16384th clock cycle if F_CPU >= 4.8 MHz. This will add some overhead when F_CPU is
+// less than 4.8 MHz. It's disabled by default because it occupies precious flash space and loads the CPU with
+// additional interrupts and calculations. Also note that micros() aren't very precise for frequencies that 64
+// doesn't divide evenly by.
+// NOTE THAT THIS MACRO CAN BE OVERRIDDEN IN ARDUINO IDE TOOLS MENU
+//#define ENABLE_MICROS
 
 #endif

--- a/avr/cores/microcore/core_settings.h
+++ b/avr/cores/microcore/core_settings.h
@@ -29,20 +29,20 @@ need in order to free up space.
 // to reflect this.
 // See table below for all supported baud rates.
 
-//#define CUSTOM_BAUD_RATE 9600
+//#define CUSTOM_BAUD_RATE 38400
 
-// | Clock & baud | 460800 | 250000 | 230400 | 115200   | 57600 | 38400    | 19200L   | 9600 | 4800 | 2400 | 1200 |
-// |--------------|--------|--------|--------|----------|-------|----------|----------|------|------|------|------|
-// | 20 MHz       | X      | X      | X      | X (def.) | X     |          |          |      |      |      |      |
-// | 16 MHz       | X      | X      | X      | X (def.) | X     | X        |          |      |      |      |      |
-// | 12 MHz       |        | X      | X      | X (def.) | X     | X        |          |      |      |      |      |
-// | 9.6 MHz      |        | X      | X      | X (def.) | X     | X        |          |      |      |      |      |
-// | 8 MHz        |        | X      | X      | X (def.) | X     | X        |          |      |      |      |      |
-// | 4.8 MHz      |        |        |        | X (def.) | X     | X        | X        | X    |      |      |      |
-// | 1.2 MHz      |        |        |        |          |       | X (def.) | X        | X    | X    | X    |      |
-// | 1 MHz        |        |        |        |          |       | X (def.) | X        | X    | X    | X    |      |
-// | 600 kHz      |        |        |        |          |       |          | X (def.) | X    | X    | X    | X    |
-// | 128 kHz      |        |        |        |          |       |          |          |      |      |      |      |
+// | Clock & baud | 460800 | 250000 | 230400 | 115200   | 57600    | 38400 | 19200    | 9600     | 4800 | 2400 | 1200 |
+// |--------------|--------|--------|--------|----------|----------|-------|----------|----------|------|------|------|
+// | 20 MHz       | X      | X      | X      | X (def.) | X        |       |          |          |      |      |      |
+// | 16 MHz       | X      | X      | X      | X (def.) | X        | X     |          |          |      |      |      |
+// | 12 MHz       |        | X      | X      | X (def.) | X        | X     |          |          |      |      |      |
+// | 9.6 MHz      |        | X      | X      | X (def.) | X        | X     |          |          |      |      |      |
+// | 8 MHz        |        | X      | X      | X (def.) | X        | X     |          |          |      |      |      |
+// | 4.8 MHz      |        |        |        | X        | X (def.) | X     | X        | X        |      |      |      |
+// | 1.2 MHz      |        |        |        |          |          | X     | X (def.) | X        | X    | X    |      |
+// | 1 MHz        |        |        |        |          |          | X     | X (def.) | X        | X    | X    |      |
+// | 600 kHz      |        |        |        |          |          |       | X        | X (def.) | X    | X    | X    |
+// | 128 kHz      |        |        |        |          |          |       |          |          |      |      |      |
 
 
 // Makes the core "idiot proof" (see wiring_digital.c and wiring_pwm.h for examples where SAFEMODE is used).

--- a/avr/cores/microcore/core_settings.h
+++ b/avr/cores/microcore/core_settings.h
@@ -65,10 +65,6 @@ need in order to free up space.
 //#define ADC_PRESCALER_128   // ADC sample rate = (F_CPU/13) / 128
 
 
-// If you're not using the PWM or want to set it up yourself, you can disable it here
-#define SETUP_PWM
-
-
 // Here's the PWM settings for Timer0
 // These settings will also be disabled if SETUP_PWM is commented out
 // Note that ENABLE_MICROS will override this setting

--- a/avr/cores/microcore/wiring.c
+++ b/avr/cores/microcore/wiring.c
@@ -1,6 +1,6 @@
 /*** MicroCore - wiring.c ***
 An Arduino core designed for ATtiny13
-Based on the work done by "smeezekitty" 
+Based on the work done by "smeezekitty"
 Modified and maintained by MCUdude
 https://github.com/MCUdude/MicroCore
 
@@ -23,7 +23,7 @@ timers.
 // The WDT uses it's own clock, so this function is valid for all F_CPUs.
 #ifdef ENABLE_MILLIS
 uint32_t millis()
-{  
+{
   uint32_t m;
   cli();
   m = wdt_interrupt_counter;
@@ -34,7 +34,7 @@ uint32_t millis()
 
 
 /***** MICROS() *****/
-// Enabling micros() will cause the processor to interrupt more often (every 2048th clock cycle if 
+// Enabling micros() will cause the processor to interrupt more often (every 2048th clock cycle if
 // F_CPU < 4.8 MHz, every 16384th clock cycle if F_CPU >= 4.8 MHz. This will add some overhead when F_CPU is
 // less than 4.8 MHz. It's disabled by default because it occupies precious flash space and loads the CPU with
 // additional interrupts and calculations. Also note that micros() aren't very precise for frequencies that 64
@@ -51,14 +51,14 @@ ISR(TIM0_OVF_vect)
 uint32_t micros()
 {
   uint32_t x;
-  uint8_t t;  
-  
-  uint8_t oldSREG = SREG; // Preserve old SREG value 
+  uint8_t t;
+
+  uint8_t oldSREG = SREG; // Preserve old SREG value
   t = TCNT0;              // Store timer0 counter value
   cli();                  // Disable global interrupts
   x = timer0_overflow;    // Store timer0 overflow count
   SREG = oldSREG;         // Restore SREG
-  
+
   #if F_CPU == 20000000L
     // Each timer tick is 1/(16MHz/64) = 3.2us long. We multiply the timer0_overflow variable
     // by 256 (bitshift 8 times) and we add the current timer count TCNT0. Since each tick is 3.2us long,
@@ -73,7 +73,7 @@ uint32_t micros()
     // Each timer tick is 1/(12MHz/64) = 5.333us long. We multiply the timer0_overflow variable
     // by 256 (bitshift 8 times) and we add the current timer count TCNT0. Since each tick is 5.333us long,
     // we multiply by 5 at the end
-    return ((x << 8) + t) * 5;  
+    return ((x << 8) + t) * 5;
   #elif F_CPU == 9600000L
     // Each timer tick is 1/(9.6MHz/64) = 6.666us long. We multiply the timer0_overflow variable
     // by 256 (bitshift 8 times) and we add the current timer count TCNT0. Since each tick is 6.666us long,
@@ -98,17 +98,17 @@ uint32_t micros()
     // Each timer tick is 1/(1MHz/8) = 8us long. We multiply the timer0_overflow variable
     // by 256 (bitshift 8 times) and we add the current timer count TCNT0. Since each tick is 8us long,
     // we multiply by 8 at the end
-    return ((x << 8) + t) * 8;  
+    return ((x << 8) + t) * 8;
   #elif F_CPU == 600000L
     // Each timer tick is 1/(600kHz/8) = 13.333us long. We multiply the timer0_overflow variable
     // by 256 (bitshift 8 times) and we add the current timer count TCNT0. Since each tick is 13.333us long,
     // we multiply by 13 at the end
-    return ((x << 8) + t) * 13;    
+    return ((x << 8) + t) * 13;
   #elif F_CPU == 128000L
     // Each timer tick is 1/(128kHz/8) = 62.5us long. We multiply the timer0_overflow variable
     // by 256 (bitshift 8 times) and we add the current timer count TCNT0. Since each tick is 62.5us long,
     // we multiply by 62 at the end
-    return ((x << 8) + t) * 62;      
+    return ((x << 8) + t) * 62;
  #endif
 
 }
@@ -121,65 +121,35 @@ void delay(uint16_t ms)
   do
     _delay_ms(1);
   while(--ms);
-    
 }
 
 
 // This init() function will be executed before the setup() function does
-// Edit the core_settings.h file to choose what's going to be initialized 
+// Edit the core_settings.h file to choose what's going to be initialized
 // and what's not.
 void init()
 {
-
-  #ifdef SETUP_PWM  
-    // Set Timer0 prescaler
-    #if defined(PWM_PRESCALER_AUTO)
-      #if F_CPU >= 4800000L
-        TCCR0B = _BV(CS00) | _BV(CS01); // PWM frequency = (F_CPU/256) / 64
-      #else  
-        TCCR0B = _BV(CS01);             // PWM frequency = (F_CPU/256) / 8
-      #endif
-    #elif defined(PWM_PRESCALER_NONE)   // PWM frequency = (F_CPU/256) / 1
-      TCCR0B = _BV(CS00);
-    #elif  defined(PWM_PRESCALER_8)     // PWM frequency = (F_CPU/256) / 8
-      TCCR0B = _BV(CS01);
-    #elif  defined(PWM_PRESCALER_64)    // PWM frequency = (F_CPU/256) / 64
-      TCCR0B = _BV(CS00) | _BV(CS01);
-    #elif  defined(PWM_PRESCALER_256)   // PWM frequency = (F_CPU/256) / 256
-      TCCR0B = _BV(CS02);
-    #elif  defined(PWM_PRESCALER_1024)  // PWM frequency = (F_CPU/256) / 1024
-      TCCR0B = _BV(CS00) | _BV(CS02);
-    #endif
-    
-    // Set waveform generation mode
-    #if defined(PWM_FAST)
-      TCCR0A = _BV(WGM00) | _BV(WGM01);
-    #elif defined(PWM_PHASE_CORRECT)
-      TCCR0A = _BV(WGM00);
-    #endif
-  #endif  
-  
-  // Enable WDT interrupt and enable global interrupts  
+  // Enable WDT interrupt and enable global interrupts
   #ifdef ENABLE_MILLIS
     // Set up WDT interrupt with 16 ms prescaler
     WDTCR = _BV(WDTIE);
     // Enable global interrupts
     sei();
   #endif
-  
+
   // WARNING! Enabling micros() will affect timing functions!
-  #ifdef ENABLE_MICROS   
+  #ifdef ENABLE_MICROS
     // Set a suited prescaler based on F_CPU
     #if F_CPU >= 4800000L
-      TCCR0B = _BV(CS00) | _BV(CS01); // F_CPU/64 
-    #else  
+      TCCR0B = _BV(CS00) | _BV(CS01); // F_CPU/64
+    #else
       TCCR0B = _BV(CS01);             // F_CPU/8
-    #endif      
+    #endif
     // Enable overflow interrupt on Timer0
     TIMSK0 = _BV(TOIE0);
     // Set timer0 couter to zero
-    TCNT0 = 0; 
+    TCNT0 = 0;
     // Turn on global interrupts
     sei();
-  #endif 
+  #endif
 }

--- a/avr/libraries/Serial_exampes/examples/ASCIItable/ASCIItable.ino
+++ b/avr/libraries/Serial_exampes/examples/ASCIItable/ASCIItable.ino
@@ -18,7 +18,6 @@
 
   Tools > Board          : ATtiny13
   Tools > BOD            : [Use any BOD level you like]
-  Tools > Compiler LTO   : LTO enabled
   Tools > Clock          : [Use any clock except 128 kHz]
   Tools > Timing         : Millis enabled, Micros disabled
 

--- a/avr/libraries/Serial_exampes/examples/ASCIItable/ASCIItable.ino
+++ b/avr/libraries/Serial_exampes/examples/ASCIItable/ASCIItable.ino
@@ -8,8 +8,8 @@
   [ See diagram: https://github.com/MCUdude/MicroCore#minimal-setup ]
 
   Prints out byte values in all possible formats:
-  * As raw binary values
-  * As ASCII-encoded decimal, hex, octal, and binary values
+    As raw binary values
+    As ASCII-encoded decimal, hex, octal, and binary values
 
   For more on ASCII, see http://www.asciitable.com and http://en.wikipedia.org/wiki/ASCII
 
@@ -47,66 +47,50 @@
 
 #include <EEPROM.h>
 
-// First visible ASCII character '!' is number 33:
-uint8_t thisByte = 33;
-// You can also write ASCII characters in single quotes.
-// For example; '!' is the same as 33, so you could also use this:
-// uint8_t thisByte = '!';
-
 void setup()
 {
   // Check if there exist any OSCCAL value in EEPROM addr. 0
   // If not, run the oscillator tuner sketch first
   uint8_t cal = EEPROM.read(0);
-  if(cal < 0x7F)
+  if (cal < 0x7F)
     OSCCAL = cal;
 
   // Note that any baud rate specified is ignored on the ATtiny13. See header above.
   Serial.begin();
 
-  // Prints title with ending line break
-  Serial.print(F("ASCII Table Map\n"));
+  // First visible ASCII character '!' is number 33
+  // Last visible ASCII character '~' is number 126
+  for (uint8_t asciiChar = 33; asciiChar < 127; asciiChar++)
+  {
+    // Prints value unaltered, i.e. the raw binary version of the
+    // byte. The serial monitor interprets all bytes as
+    // ASCII, so 33, the first number,  will show up as '!'
+    Serial.print(F("Char: "));
+    Serial.write(asciiChar);
 
-  // Wait for serial monitor to open and you to react
-  delay(2000);
+    Serial.print(F(", dec: "));
+    // Prints value as string as an ASCII-encoded decimal (base 10).
+    // Decimal is the  default format for Serial.print() and Serial.println(),
+    // so no modifier is needed:
+    Serial.print(asciiChar);
+    // But you can declare the modifier for decimal if you want to.
+    // This also works if you uncomment it:
+
+    // Serial.print(thisByte, DEC);
+
+    Serial.print(F(", hex: "));
+    // Prints value as string in hexadecimal (base 16):
+    Serial.print(asciiChar, HEX);
+
+    Serial.print(F(", bin: "));
+    // prints value as string in binary (base 2)
+    // also prints ending line break:
+    Serial.print(asciiChar, BIN);
+    Serial.write('\n');
+  }
 }
-
 
 void loop()
 {
-  // Prints value unaltered, i.e. the raw binary version of the
-  // byte. The serial monitor interprets all bytes as
-  // ASCII, so 33, the first number,  will show up as '!'
-  Serial.print(F("Char: "));
-  Serial.write(thisByte);
 
-  Serial.print(F(", dec: "));
-  // Prints value as string as an ASCII-encoded decimal (base 10).
-  // Decimal is the  default format for Serial.print() and Serial.println(),
-  // so no modifier is needed:
-  Serial.print(thisByte);
-  // But you can declare the modifier for decimal if you want to.
-  // This also works if you uncomment it:
-
-  // Serial.print(thisByte, DEC);
-
-  Serial.print(F(", hex: "));
-  // Prints value as string in hexadecimal (base 16):
-  Serial.print(thisByte, HEX);
-
-  Serial.print(F(", bin: "));
-  // prints value as string in binary (base 2)
-  // also prints ending line break:
-  Serial.print(thisByte, BIN);
-  Serial.write('\n');
-
-  // if printed last visible character '~' or 126, stop:
-  if(thisByte == 126)  // you could also use if (thisByte == '~')
-  {
-    // This loop loops forever and does nothing
-    while(true);
-  }
-  
-  // Go on to the next character
-  thisByte++;
 }

--- a/avr/libraries/Serial_exampes/examples/ASCIItable/ASCIItable.ino
+++ b/avr/libraries/Serial_exampes/examples/ASCIItable/ASCIItable.ino
@@ -46,6 +46,7 @@
    3. Check OSCCAL (see OSCCAL tuner example)
 */
 
+#include <EEPROM.h>
 
 // First visible ASCII character '!' is number 33:
 uint8_t thisByte = 33;
@@ -55,11 +56,17 @@ uint8_t thisByte = 33;
 
 void setup()
 {
+  // Check if there exist any OSCCAL value in EEPROM addr. 0
+  // If not, run the oscillator tuner sketch first
+  uint8_t cal = EEPROM.read(0);
+  if(cal < 0x7F)
+    OSCCAL = cal;
+
   // Note that any baud rate specified is ignored on the ATtiny13. See header above.
   Serial.begin();
 
   // Prints title with ending line break
-  Serial.print(F("ASCII Table ~ Character Map\n"));
+  Serial.print(F("ASCII Table Map\n"));
 
   // Wait for serial monitor to open and you to react
   delay(2000);

--- a/avr/libraries/Serial_exampes/examples/ASCIItable/ASCIItable.ino
+++ b/avr/libraries/Serial_exampes/examples/ASCIItable/ASCIItable.ino
@@ -1,0 +1,105 @@
+/*
+  Print a table of ASCII characters to the Serial Monitor
+
+  By J.Sleeman (sparks@gogo.co.nz)
+  MicroCore support by MCUdude
+  ------------------------------------------------------------------------------
+
+  [ See diagram: https://github.com/MCUdude/MicroCore#minimal-setup ]
+
+  Prints out byte values in all possible formats:
+  * As raw binary values
+  * As ASCII-encoded decimal, hex, octal, and binary values
+
+  For more on ASCII, see http://www.asciitable.com and http://en.wikipedia.org/wiki/ASCII
+
+  RECOMMENDED SETTINGS FOR THIS SKETCH
+  ------------------------------------------------------------------------------
+
+  Tools > Board          : ATtiny13
+  Tools > BOD            : [Use any BOD level you like]
+  Tools > Compiler LTO   : LTO enabled
+  Tools > Clock          : [Use any clock except 128 kHz]
+  Tools > Timing         : Millis enabled, Micros disabled
+
+  SERIAL REMINDER
+  ------------------------------------------------------------------------------
+  The baud rate is IGNORED on the ATtiny13 due to using a simplified serial.
+  The actual Baud Rate used is dependant on the processor speed.
+  Note that you can specify a custom baud rate if the following ones does
+  not fit your application.
+
+  THESE CLOCKS USES 115200 BAUD:   THIS CLOCK USES 57600 BAUD:
+  (External)  20 MHz               (Internal) 4.8 MHz
+  (External)  16 MHz
+  (External)  12 MHz
+  (External)   8 MHz
+  (Internal) 9.6 MHz
+
+  THESE CLOCKS USES 19200 BAUD:    THIS CLOCK USES 9600 BAUD:
+  (Internal) 1.2 MHz               (Internal) 600 KHz
+  (External)   1 MHz
+
+  If you get garbage output:
+   1. Check baud rate as above
+   2. Check if you have anything else connected to TX/RX like an LED
+   3. Check OSCCAL (see OSCCAL tuner example)
+*/
+
+
+// First visible ASCII character '!' is number 33:
+uint8_t thisByte = 33;
+// You can also write ASCII characters in single quotes.
+// For example; '!' is the same as 33, so you could also use this:
+// uint8_t thisByte = '!';
+
+void setup()
+{
+  // Note that any baud rate specified is ignored on the ATtiny13. See header above.
+  Serial.begin();
+
+  // Prints title with ending line break
+  Serial.println(F("ASCII Table ~ Character Map"));
+
+  // Wait for serial monitor to open and you to react
+  delay(2000);
+}
+
+
+void loop()
+{
+  // Prints value unaltered, i.e. the raw binary version of the
+  // byte. The serial monitor interprets all bytes as
+  // ASCII, so 33, the first number,  will show up as '!'
+  Serial.print(F("Char: "));
+  Serial.write(thisByte);
+
+  Serial.print(F(", dec: "));
+  // Prints value as string as an ASCII-encoded decimal (base 10).
+  // Decimal is the  default format for Serial.print() and Serial.println(),
+  // so no modifier is needed:
+  Serial.print(thisByte);
+  // But you can declare the modifier for decimal if you want to.
+  //this also works if you uncomment it:
+
+  // Serial.print(thisByte, DEC);
+
+  Serial.print(F(", hex: "));
+  // Prints value as string in hexadecimal (base 16):
+  Serial.print(thisByte, HEX);
+
+  Serial.print(F(", bin: "));
+  // prints value as string in binary (base 2)
+  // also prints ending line break:
+  Serial.println(thisByte, BIN);
+
+  // if printed last visible character '~' or 126, stop:
+  if(thisByte == 126)  // you could also use if (thisByte == '~')
+  {
+    // This loop loops forever and does nothing
+    while(true);
+  }
+  
+  // Go on to the next character
+  thisByte++;
+}

--- a/avr/libraries/Serial_exampes/examples/ASCIItable/ASCIItable.ino
+++ b/avr/libraries/Serial_exampes/examples/ASCIItable/ASCIItable.ino
@@ -59,7 +59,7 @@ void setup()
   Serial.begin();
 
   // Prints title with ending line break
-  Serial.println(F("ASCII Table ~ Character Map"));
+  Serial.print(F("ASCII Table ~ Character Map\n"));
 
   // Wait for serial monitor to open and you to react
   delay(2000);
@@ -80,7 +80,7 @@ void loop()
   // so no modifier is needed:
   Serial.print(thisByte);
   // But you can declare the modifier for decimal if you want to.
-  //this also works if you uncomment it:
+  // This also works if you uncomment it:
 
   // Serial.print(thisByte, DEC);
 
@@ -91,7 +91,8 @@ void loop()
   Serial.print(F(", bin: "));
   // prints value as string in binary (base 2)
   // also prints ending line break:
-  Serial.println(thisByte, BIN);
+  Serial.print(thisByte, BIN);
+  Serial.write('\n');
 
   // if printed last visible character '~' or 126, stop:
   if(thisByte == 126)  // you could also use if (thisByte == '~')

--- a/avr/libraries/Serial_exampes/examples/MenuDemo/MenuDemo.ino
+++ b/avr/libraries/Serial_exampes/examples/MenuDemo/MenuDemo.ino
@@ -15,7 +15,6 @@
 
   Tools > Board          : ATtiny13
   Tools > BOD            : [Use any BOD level you like]
-  Tools > Compiler LTO   : LTO enabled
   Tools > Clock          : [Use any clock except 128 kHz]
   Tools > Timing         : Millis enabled, Micros disabled
 

--- a/avr/libraries/Serial_exampes/examples/MenuDemo/MenuDemo.ino
+++ b/avr/libraries/Serial_exampes/examples/MenuDemo/MenuDemo.ino
@@ -43,9 +43,16 @@
    3. Check OSCCAL (see OSCCAL tuner example)
 */
 
+#include <EEPROM.h>
 
 void setup() 
 {
+  // Check if there exist any OSCCAL value in EEPROM addr. 0
+  // If not, run the oscillator tuner sketch first
+  uint8_t cal = EEPROM.read(0);
+  if(cal < 0x7F)
+    OSCCAL = cal;
+
   // Note that any baud rate specified is ignored on the ATtiny13. See header above.
   Serial.begin();
 }

--- a/avr/libraries/Serial_exampes/examples/MenuDemo/MenuDemo.ino
+++ b/avr/libraries/Serial_exampes/examples/MenuDemo/MenuDemo.ino
@@ -1,0 +1,81 @@
+/*
+  Print menu to Serial, read selection from Serial
+
+  By J.Sleeman (sparks@gogo.co.nz)
+  MicroCore support by MCUdude
+  ------------------------------------------------------------------------------
+
+  [ See diagram: https://github.com/MCUdude/MicroCore#minimal-setup ]
+
+  Gives you some options, allows you to pick from them by sending a single
+  character.  Blocks until you choose.
+
+  RECOMMENDED SETTINGS FOR THIS SKETCH
+  ------------------------------------------------------------------------------
+
+  Tools > Board          : ATtiny13
+  Tools > BOD            : [Use any BOD level you like]
+  Tools > Compiler LTO   : LTO enabled
+  Tools > Clock          : [Use any clock except 128 kHz]
+  Tools > Timing         : Millis enabled, Micros disabled
+
+  SERIAL REMINDER
+  ------------------------------------------------------------------------------
+  The baud rate is IGNORED on the ATtiny13 due to using a simplified serial.
+  The actual Baud Rate used is dependant on the processor speed.
+  Note that you can specify a custom baud rate if the following ones does
+  not fit your application.
+
+  THESE CLOCKS USES 115200 BAUD:   THIS CLOCK USES 57600 BAUD:
+  (External)  20 MHz               (Internal) 4.8 MHz
+  (External)  16 MHz
+  (External)  12 MHz
+  (External)   8 MHz
+  (Internal) 9.6 MHz
+
+  THESE CLOCKS USES 19200 BAUD:    THIS CLOCK USES 9600 BAUD:
+  (Internal) 1.2 MHz               (Internal) 600 KHz
+  (External)   1 MHz
+
+  If you get garbage output:
+   1. Check baud rate as above
+   2. Check if you have anything else connected to TX/RX like an LED
+   3. Check OSCCAL (see OSCCAL tuner example)
+*/
+
+
+void setup() 
+{
+  // Note that any baud rate specified is ignored on the ATtiny13. See header above.
+  Serial.begin();
+}
+
+void loop() 
+{
+  Serial.println(F("\n~~ Tiny Menu ~~\n"));  
+  Serial.println(F("1. Say Hello"));
+  Serial.println(F("2. Say Goodbye"));
+  Serial.println(F("3. Sing"));
+  Serial.println(F("4. Jack"));
+
+  switch(Serial.read_char_blocking())
+  {
+    case '1':
+      Serial.println(F(">> Hello"));
+      break;
+    case '2':
+      Serial.println(F(">> Goodbye"));
+      break;
+    case '3':
+      Serial.println(F(">> Daisy, daisy, give me your answer do."));
+      break;
+    case '4':
+      for(uint8_t x = 0; x < 100; x++)
+        Serial.println(F("All work and no play makes Jack a dull boy."));       
+      break;
+    default:
+      Serial.println(F("* Unkown Command *"));
+      break;
+  }
+  delay(1000);
+}

--- a/avr/libraries/Serial_exampes/examples/OscillatorCalibration/OscillatorCalibration.ino
+++ b/avr/libraries/Serial_exampes/examples/OscillatorCalibration/OscillatorCalibration.ino
@@ -1,0 +1,147 @@
+/*
+  ATtiny13 internal oscillator tuner
+
+  By Ralph Doncaster (2019)
+  Tweaked and tuned by MCUdude
+  ------------------------------------------------------------------------------
+
+  [ See diagram: https://github.com/MCUdude/MicroCore#minimal-setup ]
+
+  Tunes the internal oscillator using a software serial implementation
+
+  Start off by opening the serial monitor and select the correct baud rate.
+  Make sure you're not sending any line ending characters (CR, LF).
+  Repedeatly press 'x' [send] to tune the internal oscillator. After a few
+  messages you'll eventually see readable text in the serial monitor, and a
+  new, stable OSCCAL value. Remember to store this value to EEPROM (or hard-code
+  it in your code) in order to have an accurate oscillator in future projects.
+
+  RECOMMENDED SETTINGS FOR THIS SKETCH
+  ------------------------------------------------------------------------------
+
+  Tools > Board          : ATtiny13
+  Tools > BOD            : [Use any BOD level you like]
+  Tools > Compiler LTO   : LTO enabled
+  Tools > Clock          : 9.6 MHz or 4.8 MHz depending on what osc. to tune
+  Tools > Timing         : Millis disabled, Micros disabled
+
+  SERIAL REMINDER
+  ------------------------------------------------------------------------------
+  The baud rate is IGNORED on the ATtiny13 due to using a simplified serial.
+  The actual Baud Rate used is dependant on the processor speed.
+  Note that you can specify a custom baud rate if the following ones does
+  not fit your application.
+
+  THESE CLOCKS USES 115200 BAUD:   THIS CLOCK USES 57600 BAUD:
+  (External)  20 MHz               (Internal) 4.8 MHz
+  (External)  16 MHz
+  (External)  12 MHz
+  (External)   8 MHz
+  (Internal) 9.6 MHz
+
+  THESE CLOCKS USES 19200 BAUD:    THIS CLOCK USES 9600 BAUD:
+  (Internal) 1.2 MHz               (Internal) 600 KHz
+  (External)   1 MHz
+
+  If you get garbage output:
+   1. Check baud rate as above
+   2. Check if you have anything else connected to TX/RX like an LED
+   3. You haven't sent enough 'x' characters yet
+*/
+
+const int8_t delta_val = 8;
+const uint8_t uart_rx_pin = 1;
+uint8_t oldOSCCAL;
+
+// Converts 4-bit nibble to ascii hex
+uint8_t nibbletohex(uint8_t value)
+{
+  value &= 0x0F;
+  if (value > 9)
+    value += 'A' - ':';
+  return value + '0';
+}
+
+// Function to run when Rx interrupt occurs
+void rxInterrupt()
+{
+  // Start timer when pin transitions low
+  if ((PINB & _BV(uart_rx_pin)) == 0)
+    TCCR0B = _BV(CS00);
+  else
+  {
+    uint8_t current = TCNT0;
+    // End of interval, reset counter
+    TCCR0B = 0;
+    TCNT0 = 0;
+    // 'x' begins with 3 zeros + start bit = 4
+    uint8_t target = (uint8_t)(4 * F_CPU / BAUD_RATE);
+    int8_t delta = target - current;
+    if (delta > delta_val)  OSCCAL++;
+    if (delta < -delta_val) OSCCAL--;
+    asm("lpm"); // 3 cycle delay
+    // Print calculation
+    Serial.print(F("Delta: 0x"));
+    Serial.write(nibbletohex(delta >> 4));
+    Serial.write(nibbletohex(delta));
+    Serial.print(F("  New cal: 0x"));
+    Serial.write(nibbletohex(OSCCAL >> 4));
+    Serial.write(nibbletohex(OSCCAL));
+    Serial.write('\n');
+  }
+ 
+  // Clear interrupt flag in case another triggered
+  GIFR = _BV(INTF0);
+}
+
+void setup() 
+{
+  // Note that any baud rate specified is ignored on the ATtiny13. See header above.
+  Serial.begin();
+  
+  // Store old OSCCAL value for reference
+  oldOSCCAL = OSCCAL;
+  
+  // Prepare for sleep mode
+  MCUCR = _BV(SE);
+
+  // Enable Rx pin pullup
+  digitalWrite(uart_rx_pin,HIGH);
+  
+  // Setup RX interrupt
+  attachInterrupt(0, rxInterrupt, CHANGE);
+  
+  delay(1000);
+
+  // Print default message
+  Serial.write('x');
+  Serial.write('\n');
+  
+  // Wait for tuning character to ensure not reading noise
+  // before entering tuning mode
+  wait_x:
+  uint8_t counter = 0;
+  while (digitalRead(uart_rx_pin));
+  do 
+  {
+    counter++;
+  } while (digitalRead(uart_rx_pin) == 0);
+
+  // Low period should be 4 bit-times
+  uint8_t margin = BIT_CYCLES/8;
+  if (counter - (uint8_t)BIT_CYCLES > margin)
+    goto wait_x;
+  else
+  {
+    if ((uint8_t)BIT_CYCLES - counter > margin)
+      goto wait_x;
+  }
+
+  delay(1); // Skip remaining bits in frame
+}
+
+void loop() 
+{
+  // Nothing here really...
+  asm("sleep");
+}

--- a/avr/libraries/Serial_exampes/examples/OscillatorCalibration/OscillatorCalibration.ino
+++ b/avr/libraries/Serial_exampes/examples/OscillatorCalibration/OscillatorCalibration.ino
@@ -23,7 +23,6 @@
 
   Tools > Board          : ATtiny13
   Tools > BOD            : [Use any BOD level you like]
-  Tools > Compiler LTO   : LTO enabled
   Tools > Clock          : 9.6 MHz or 4.8 MHz depending on what osc. to tune
   Tools > Timing         : Millis disabled, Micros disabled
 

--- a/avr/libraries/Serial_exampes/examples/ReadASCIIString/ReadASCIIString.ino
+++ b/avr/libraries/Serial_exampes/examples/ReadASCIIString/ReadASCIIString.ino
@@ -20,7 +20,6 @@
 
   Tools > Board          : ATtiny13
   Tools > BOD            : [Use any BOD level you like]
-  Tools > Compiler LTO   : LTO enabled
   Tools > Clock          : [Use any clock except 128 kHz]
   Tools > Timing         : Millis enabled, Micros disabled
 

--- a/avr/libraries/Serial_exampes/examples/ReadASCIIString/ReadASCIIString.ino
+++ b/avr/libraries/Serial_exampes/examples/ReadASCIIString/ReadASCIIString.ino
@@ -1,0 +1,69 @@
+/*
+  Read string from Serial, Print string to Serial
+
+  By J.Sleeman (sparks@gogo.co.nz)
+  MicroCore support by MCUdude
+  ------------------------------------------------------------------------------
+
+  [ See diagram: https://github.com/MCUdude/MicroCore#minimal-setup ]
+
+  Asks your name, says hello. Not very exciting, but anyway.
+
+  There is an important note here with regard to reading strings over
+  Serial on the ATtiny13.  Because of a lack of hardware serial support
+  interrupts are disabled for the ENTIRE READ of the string. This means that
+  millis() will "lose time" for the period you are reading the string.
+  Just bear that in mind.
+
+  RECOMMENDED SETTINGS FOR THIS SKETCH
+  ------------------------------------------------------------------------------
+
+  Tools > Board          : ATtiny13
+  Tools > BOD            : [Use any BOD level you like]
+  Tools > Compiler LTO   : LTO enabled
+  Tools > Clock          : [Use any clock except 128 kHz]
+  Tools > Timing         : Millis enabled, Micros disabled
+
+  SERIAL REMINDER
+  ------------------------------------------------------------------------------
+  The baud rate is IGNORED on the ATtiny13 due to using a simplified serial.
+  The actual Baud Rate used is dependant on the processor speed.
+  Note that you can specify a custom baud rate if the following ones does
+  not fit your application.
+
+  THESE CLOCKS USES 115200 BAUD:   THIS CLOCK USES 57600 BAUD:
+  (External)  20 MHz               (Internal) 4.8 MHz
+  (External)  16 MHz
+  (External)  12 MHz
+  (External)   8 MHz
+  (Internal) 9.6 MHz
+
+  THESE CLOCKS USES 19200 BAUD:    THIS CLOCK USES 9600 BAUD:
+  (Internal) 1.2 MHz               (Internal) 600 KHz
+  (External)   1 MHz
+
+  If you get garbage output:
+   1. Check baud rate as above
+   2. Check if you have anything else connected to TX/RX like an LED
+   3. Check OSCCAL (see OSCCAL tuner example)
+*/
+
+
+void setup()
+{
+  // Note that any baud rate specified is ignored on the ATtiny13. See header above.
+  Serial.begin();
+}
+
+void loop()
+{
+  Serial.println(F("What is your name traveler?"));
+  char buf[15];
+  do
+  {
+    Serial.read_str(buf, sizeof(buf));
+  } while (!buf[0]);
+
+  Serial.print(F("Nice to meet you "));
+  Serial.println(buf);
+}

--- a/avr/libraries/Serial_exampes/examples/ReadASCIIString/ReadASCIIString.ino
+++ b/avr/libraries/Serial_exampes/examples/ReadASCIIString/ReadASCIIString.ino
@@ -48,9 +48,16 @@
    3. Check OSCCAL (see OSCCAL tuner example)
 */
 
+#include <EEPROM.h>
 
 void setup()
 {
+  // Check if there exist any OSCCAL value in EEPROM addr. 0
+  // If not, run the oscillator tuner sketch first
+  uint8_t cal = EEPROM.read(0);
+  if(cal < 0x7F)
+    OSCCAL = cal;
+
   // Note that any baud rate specified is ignored on the ATtiny13. See header above.
   Serial.begin();
 }

--- a/avr/libraries/Serial_exampes/keywords.txt
+++ b/avr/libraries/Serial_exampes/keywords.txt
@@ -1,0 +1,17 @@
+#######################################
+# Syntax Coloring Map Serial examples
+#######################################
+
+#######################################
+# Datatypes (KEYWORD1)
+#######################################
+
+
+#######################################
+# Methods and Functions (KEYWORD2)
+#######################################
+read_byte	KEYWORD2
+read_char	KEYWORD2
+read_char_blocking	KEYWORD2
+read_str	KEYWORD2
+write_byte	KEYWORD2

--- a/avr/libraries/Serial_exampes/library.properties
+++ b/avr/libraries/Serial_exampes/library.properties
@@ -1,0 +1,10 @@
+name=Serial examples
+version=1.0
+author=MCUdude
+maintainer=MCUdude
+sentence=Serial examples for MicroCore
+paragraph=
+category=Communication
+url=https://github.com/MCUdude/MicroCore
+architectures=avr
+types=Arduino

--- a/avr/libraries/Serial_exampes/src/Serial_examples.h
+++ b/avr/libraries/Serial_exampes/src/Serial_examples.h
@@ -1,0 +1,1 @@
+// This file causes the Arduino IDE to see the Serial examples as a valid library 

--- a/avr/variants/attiny13/pins_arduino.h
+++ b/avr/variants/attiny13/pins_arduino.h
@@ -63,7 +63,7 @@ specific hardware definitions.
 #define digitalPinToPCMSKbit(p)    (p)
 
 
-#define LED_BUILTIN 0
+#define LED_BUILTIN 2
 static const uint8_t MOSI = 0;
 static const uint8_t MISO = 1;
 static const uint8_t SCK  = 2;


### PR DESCRIPTION
We finally have proper "Arduino-like" serial communication. Another issue with the ATtiny13 is that the internal oscillator is known to be way out of tune, especially those sourced from China. This PR also includes a nice oscillator calibration sketch that uses a serial interface for tuning.
Closes #88 and closes #89.