### PR TITLE
auto include millis

### DIFF
--- a/avr/boards.txt
+++ b/avr/boards.txt
@@ -122,14 +122,7 @@ attiny13.menu.lto.Os.ltoarcmd=avr-ar
 #### Timing ####
 ################
 
-attiny13.menu.timing.millis_enabled_micros_disabled=Millis enabled, Micros disabled
-attiny13.menu.timing.millis_enabled_micros_disabled.build.timing=-DENABLE_MILLIS
-
-attiny13.menu.timing.millis_enabled_micros_enabled=Millis enabled, Micros enabled
-attiny13.menu.timing.millis_enabled_micros_enabled.build.timing=-DENABLE_MILLIS -DENABLE_MICROS
-
-attiny13.menu.timing.millis_disabled_micros_enabled=Millis disabled, Micros enabled
-attiny13.menu.timing.millis_disabled_micros_enabled.build.timing=-DENABLE_MICROS
-
-attiny13.menu.timing.millis_disabled_micros_disabled=Millis disabled, Micros disabled
-attiny13.menu.timing.millis_disabled_micros_disabled.build.timing=
+attiny13.menu.timing.micros_enabled=Micros enabled
+attiny13.menu.timing.micros_enabled.build.timing=-DENABLE_MICROS
+attiny13.menu.timing.micros_disabled=Micros disabled
+attiny13.menu.timing.micros_disabled.build.timing=

--- a/avr/cores/microcore/Arduino.h
+++ b/avr/cores/microcore/Arduino.h
@@ -23,7 +23,7 @@ https://github.com/MCUdude/MicroCore
 #include "binary.h"
 
 // Millis counter variable defined in millis.S
-extern uint32_t wdt_interrupt_counter;
+extern volatile uint32_t wdt_interrupt_counter;
 
 // timer0 count variable defined in wiring.c
 extern volatile uint32_t timer0_overflow;

--- a/avr/cores/microcore/core_settings.h
+++ b/avr/cores/microcore/core_settings.h
@@ -81,14 +81,6 @@ need in order to free up space.
 //#define PWM_PHASE_CORRECT
 
 
-// If you're not using millis(), you can save about 100 bytes by commenting this out.
-// Note that the millis() interrupt is based on the watch dog timer, and will interrupt
-// every 16th ms (which is very little. This means the millis() function will not be
-// accurate down to 1 ms, but will increase with steps of 16.
-// NOTE THAT THIS MACRO CAN BE OVERRIDDEN IN ARDUINO IDE TOOLS MENU
-//#define ENABLE_MILLIS
-
-
 // Enabling micros() will cause the processor to interrupt more often (every 2048th clock cycle if
 // F_CPU < 4.8 MHz, every 16384th clock cycle if F_CPU >= 4.8 MHz. This will add some overhead when F_CPU is
 // less than 4.8 MHz. It's disabled by default because it occupies precious flash space and loads the CPU with

--- a/avr/cores/microcore/millis.S
+++ b/avr/cores/microcore/millis.S
@@ -23,17 +23,27 @@ ISR(WDT_vect)
 #define __SFR_OFFSET 0
 #include <avr/io.h>
 
-.section .bss
+;.section .bss
 .global __do_clear_bss
 
-; 5 byte global variable in RAM + overflow byte
-.lcomm wdt_interrupt_counter, 5
-.global wdt_interrupt_counter
+; 4 byte global variable in RAM + overflow byte
+.lcomm wdt_millis_counter, 5
+.global wdt_millis_counter
 
-.section .text
+.section .text.millis
+
+; return millis counter ulong in r24:r27
+.global _millis
+_millis:
+    ldi ZL, lo8(wdt_millis_counter)
+    cli
+    ld r24, Z+
+    ld r25, Z+
+    ld r26, Z+
+    ld r27, Z+
+    reti
 
 #define tmp1 r16
-#define tmp2 r17
 
 .global WDT_vect
 WDT_vect:
@@ -41,19 +51,24 @@ WDT_vect:
     in ZL, SREG
     push ZL                             ; Save SREG
     push tmp1
-    ldi ZL, lo8(wdt_interrupt_counter)  ; Must be 8-byte aligned
+    ldi ZL, lo8(wdt_millis_counter)
     ld tmp1, Z
-    sbci tmp1, -19                      ; Multiply by 19 because the WDT clock isn't really 128 kHz
+    subi tmp1, -19                      ; add 19 (not 16) because the WDT clock isn't really 128 kHz
     rjmp save
-add:
+add1:
     ld tmp1, Z
     sbci tmp1, -1
 save:
     st Z+, tmp1
-    brcc add
+    brcc add1
     pop tmp1
     pop ZL
     out SREG, ZL
     pop ZL
     reti
-    
+
+.section .init8
+    ldi r16, 1<<WDTIE
+    out WDTCR, r16
+    sei
+

--- a/avr/cores/microcore/wiring.c
+++ b/avr/cores/microcore/wiring.c
@@ -21,16 +21,17 @@ timers.
 // The millis counter is based on the watchdog timer, and takes very little processing time and power.
 // If 16 ms accuracy is enough, I strongly recommend you to use millis() instead of micros().
 // The WDT uses it's own clock, so this function is valid for all F_CPUs.
-#ifdef ENABLE_MILLIS
+
+// C wrapper function for _millis asm code
+// reduces compiler register pressure vs avr-gcc calling convention
+// http://nerdralph.blogspot.ca/2015/12/lightweight-avr-assembler-functions.html
 uint32_t millis()
-{
+{  
   uint32_t m;
-  cli();
-  m = wdt_interrupt_counter;
-  sei();
-  return m;
+  // jump to _millis, return count in upper registers, clobbers r30
+  asm volatile ("rcall _millis" : "=w" (m) :: "r30");
+    return m;
 }
-#endif // ENABLE_MILLIS
 
 
 /***** MICROS() *****/

--- a/avr/cores/microcore/wiring.c
+++ b/avr/cores/microcore/wiring.c
@@ -130,14 +130,6 @@ void delay(uint16_t ms)
 // and what's not.
 void init()
 {
-  // Enable WDT interrupt and enable global interrupts
-  #ifdef ENABLE_MILLIS
-    // Set up WDT interrupt with 16 ms prescaler
-    WDTCR = _BV(WDTIE);
-    // Enable global interrupts
-    sei();
-  #endif
-
   // WARNING! Enabling micros() will affect timing functions!
   #ifdef ENABLE_MICROS
     // Set a suited prescaler based on F_CPU


### PR DESCRIPTION
no more #define for millis.  Calling millis() in a sketch will cause the millis.S code to be linked in.