### PR TITLE
operator bool for compatibility

### DIFF
--- a/avr/cores/microcore/HalfDuplexSerial.h
+++ b/avr/cores/microcore/HalfDuplexSerial.h
@@ -168,6 +168,7 @@ class HalfDuplexSerial
     int16_t available();           // As we do not have a buffer, this always returns 0
     int16_t peek();                // As we do not have a buffer, this always returns -1
     void flush() { }               // Does NOTHING, you have no need to call this, here only for compatibility
+    inline operator bool() const {return true;}//always true for compatibility with `while(!Serial);`
 
     int16_t read(void);
     


### PR DESCRIPTION
adding `operator bool()` for compatibility with `HardwareSerial`, makes use of this code `while(!Serial);` ok for all