### PR TITLE
Add slow mode for STK500

### DIFF
--- a/avr/programmers.txt
+++ b/avr/programmers.txt
@@ -129,3 +129,13 @@ stk500.upload.protocol=stk500
 stk500.program.protocol=stk500
 stk500.program.tool=avrdude
 stk500.program.extra_params= -P {serial.port}
+
+stk500_slow.name=STK500 as ISP slow
+stk500_slow.communication=serial
+stk500_slow.protocol=stk500
+stk500_slow.upload.protocol=stk500
+stk500_slow.program.protocol=stk500
+stk500_slow.program.tool=avrdude
+stk500_slow.program.extra_params=-B128 -P{serial.port}
+
+


### PR DESCRIPTION
After changing the clock of my ATtiny13 to 128kHz, I couldn't connect with my Diamex ISP-PROG (STK500).
A slower mode was the solution.